### PR TITLE
Change SvgSymbol namespace.

### DIFF
--- a/Generators/AvailableElementsGenerator.cs
+++ b/Generators/AvailableElementsGenerator.cs
@@ -255,6 +255,9 @@ namespace Svg
                     }
                 }
 
+                if (string.Empty.Equals(elementName))
+                    continue;
+
                 if (elementName is not null && items.TryGetValue(elementName, out var element))
                 {
                     element.ClassNames.Add(classNameSvgElement);

--- a/Source/Document Structure/SvgSymbol.cs
+++ b/Source/Document Structure/SvgSymbol.cs
@@ -108,7 +108,6 @@ namespace Svg.Document_Structure
     /// An element used to group SVG shapes.
     /// </summary>
     [Obsolete("Use Svg.DocumentStructure.SvgSymbol.")]
-    [SvgElement("symbol")]
     public partial class SvgSymbol : SvgVisualElement
     {
         /// <summary>
@@ -199,6 +198,14 @@ namespace Svg.Document_Structure
         public override SvgElement DeepCopy()
         {
             return DeepCopy<SvgSymbol>();
+        }
+
+        public override void Write(System.Xml.XmlTextWriter writer)
+        {
+            var symbol = base.DeepCopy<Svg.DocumentStructure.SvgSymbol>() as Svg.DocumentStructure.SvgSymbol;
+            symbol.ViewBox = ViewBox;
+            symbol.AspectRatio = AspectRatio;
+            symbol.Write(writer);
         }
     }
 }

--- a/Source/Document Structure/SvgSymbol.cs
+++ b/Source/Document Structure/SvgSymbol.cs
@@ -2,7 +2,7 @@
 using System.Drawing;
 using System.Drawing.Drawing2D;
 
-namespace Svg.DocumentStructure
+namespace Svg
 {
     /// <summary>
     /// An element used to group SVG shapes.
@@ -104,9 +104,9 @@ namespace Svg.DocumentStructure
 
 namespace Svg.Document_Structure
 {
-    [Obsolete("Use Svg.DocumentStructure.SvgSymbol.")]
+    [Obsolete("Use Svg.SvgSymbol.")]
     [SvgElement("")]
-    public partial class SvgSymbol : DocumentStructure.SvgSymbol
+    public partial class SvgSymbol : Svg.SvgSymbol
     {
         public SvgSymbol()
         {

--- a/Source/Document Structure/SvgSymbol.cs
+++ b/Source/Document Structure/SvgSymbol.cs
@@ -104,108 +104,15 @@ namespace Svg.DocumentStructure
 
 namespace Svg.Document_Structure
 {
-    /// <summary>
-    /// An element used to group SVG shapes.
-    /// </summary>
     [Obsolete("Use Svg.DocumentStructure.SvgSymbol.")]
-    public partial class SvgSymbol : SvgVisualElement
+    [SvgElement("")]
+    public partial class SvgSymbol : DocumentStructure.SvgSymbol
     {
-        /// <summary>
-        /// Gets or sets the viewport of the element.
-        /// </summary>
-        /// <value></value>
-        [SvgAttribute("viewBox")]
-        public SvgViewBox ViewBox
+        public SvgSymbol()
         {
-            get { return GetAttribute<SvgViewBox>("viewBox", false); }
-            set { Attributes["viewBox"] = value; }
-        }
-
-        /// <summary>
-        /// Gets or sets the aspect of the viewport.
-        /// </summary>
-        /// <value></value>
-        [SvgAttribute("preserveAspectRatio")]
-        public SvgAspectRatio AspectRatio
-        {
-            get { return GetAttribute<SvgAspectRatio>("preserveAspectRatio", false); }
-            set { Attributes["preserveAspectRatio"] = value; }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="GraphicsPath"/> for this element.
-        /// </summary>
-        /// <value></value>
-        public override GraphicsPath Path(ISvgRenderer renderer)
-        {
-            return GetPaths(this, renderer);
-        }
-
-        /// <summary>
-        /// Gets the bounds of the element.
-        /// </summary>
-        /// <value>The bounds.</value>
-        public override RectangleF Bounds
-        {
-            get
-            {
-                var r = new RectangleF();
-                foreach (var c in this.Children)
-                {
-                    if (c is SvgVisualElement)
-                    {
-                        // First it should check if rectangle is empty or it will return the wrong Bounds.
-                        // This is because when the Rectangle is Empty, the Union method adds as if the first values where X=0, Y=0
-                        if (r.IsEmpty)
-                        {
-                            r = ((SvgVisualElement)c).Bounds;
-                        }
-                        else
-                        {
-                            var childBounds = ((SvgVisualElement)c).Bounds;
-                            if (!childBounds.IsEmpty)
-                            {
-                                r = RectangleF.Union(r, childBounds);
-                            }
-                        }
-                    }
-                }
-
-                return TransformedBounds(r);
-            }
-        }
-
-        protected override bool Renderable { get { return false; } }
-
-        /// <summary>
-        /// Applies the required transforms to <see cref="ISvgRenderer"/>.
-        /// </summary>
-        /// <param name="renderer">The <see cref="ISvgRenderer"/> to be transformed.</param>
-        protected internal override bool PushTransforms(ISvgRenderer renderer)
-        {
-            if (!base.PushTransforms(renderer))
-                return false;
-            ViewBox.AddViewBoxTransform(AspectRatio, renderer, null);
-            return true;
-        }
-
-        // Only render if the parent is set to a Use element
-        protected override void Render(ISvgRenderer renderer)
-        {
-            if (_parent is SvgUse) base.Render(renderer);
-        }
-
-        public override SvgElement DeepCopy()
-        {
-            return DeepCopy<SvgSymbol>();
-        }
-
-        public override void Write(System.Xml.XmlTextWriter writer)
-        {
-            var symbol = base.DeepCopy<Svg.DocumentStructure.SvgSymbol>() as Svg.DocumentStructure.SvgSymbol;
-            symbol.ViewBox = ViewBox;
-            symbol.AspectRatio = AspectRatio;
-            symbol.Write(writer);
+            typeof(SvgElement)
+                .GetField("_elementName", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                .SetValue(this, "symbol");
         }
     }
 }

--- a/Source/Document Structure/SvgSymbol.cs
+++ b/Source/Document Structure/SvgSymbol.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 
-namespace Svg.Document_Structure
+namespace Svg.DocumentStructure
 {
     /// <summary>
     /// An element used to group SVG shapes.
@@ -35,10 +33,10 @@ namespace Svg.Document_Structure
         }
 
         /// <summary>
-        /// Gets the <see cref="System.Drawing.Drawing2D.GraphicsPath"/> for this element.
+        /// Gets the <see cref="GraphicsPath"/> for this element.
         /// </summary>
         /// <value></value>
-        public override System.Drawing.Drawing2D.GraphicsPath Path(ISvgRenderer renderer)
+        public override GraphicsPath Path(ISvgRenderer renderer)
         {
             return GetPaths(this, renderer);
         }
@@ -47,7 +45,108 @@ namespace Svg.Document_Structure
         /// Gets the bounds of the element.
         /// </summary>
         /// <value>The bounds.</value>
-        public override System.Drawing.RectangleF Bounds
+        public override RectangleF Bounds
+        {
+            get
+            {
+                var r = new RectangleF();
+                foreach (var c in this.Children)
+                {
+                    if (c is SvgVisualElement)
+                    {
+                        // First it should check if rectangle is empty or it will return the wrong Bounds.
+                        // This is because when the Rectangle is Empty, the Union method adds as if the first values where X=0, Y=0
+                        if (r.IsEmpty)
+                        {
+                            r = ((SvgVisualElement)c).Bounds;
+                        }
+                        else
+                        {
+                            var childBounds = ((SvgVisualElement)c).Bounds;
+                            if (!childBounds.IsEmpty)
+                            {
+                                r = RectangleF.Union(r, childBounds);
+                            }
+                        }
+                    }
+                }
+
+                return TransformedBounds(r);
+            }
+        }
+
+        protected override bool Renderable { get { return false; } }
+
+        /// <summary>
+        /// Applies the required transforms to <see cref="ISvgRenderer"/>.
+        /// </summary>
+        /// <param name="renderer">The <see cref="ISvgRenderer"/> to be transformed.</param>
+        protected internal override bool PushTransforms(ISvgRenderer renderer)
+        {
+            if (!base.PushTransforms(renderer))
+                return false;
+            ViewBox.AddViewBoxTransform(AspectRatio, renderer, null);
+            return true;
+        }
+
+        // Only render if the parent is set to a Use element
+        protected override void Render(ISvgRenderer renderer)
+        {
+            if (_parent is SvgUse) base.Render(renderer);
+        }
+
+        public override SvgElement DeepCopy()
+        {
+            return DeepCopy<SvgSymbol>();
+        }
+    }
+}
+
+namespace Svg.Document_Structure
+{
+    /// <summary>
+    /// An element used to group SVG shapes.
+    /// </summary>
+    [Obsolete("Use Svg.DocumentStructure.SvgSymbol.")]
+    [SvgElement("symbol")]
+    public partial class SvgSymbol : SvgVisualElement
+    {
+        /// <summary>
+        /// Gets or sets the viewport of the element.
+        /// </summary>
+        /// <value></value>
+        [SvgAttribute("viewBox")]
+        public SvgViewBox ViewBox
+        {
+            get { return GetAttribute<SvgViewBox>("viewBox", false); }
+            set { Attributes["viewBox"] = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the aspect of the viewport.
+        /// </summary>
+        /// <value></value>
+        [SvgAttribute("preserveAspectRatio")]
+        public SvgAspectRatio AspectRatio
+        {
+            get { return GetAttribute<SvgAspectRatio>("preserveAspectRatio", false); }
+            set { Attributes["preserveAspectRatio"] = value; }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="GraphicsPath"/> for this element.
+        /// </summary>
+        /// <value></value>
+        public override GraphicsPath Path(ISvgRenderer renderer)
+        {
+            return GetPaths(this, renderer);
+        }
+
+        /// <summary>
+        /// Gets the bounds of the element.
+        /// </summary>
+        /// <value>The bounds.</value>
+        public override RectangleF Bounds
         {
             get
             {

--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -6,6 +6,7 @@ using System.Drawing.Drawing2D;
 using System.Linq;
 using System.Reflection;
 using System.Xml;
+using Svg.DocumentStructure;
 using Svg.Transforms;
 
 namespace Svg
@@ -1059,7 +1060,7 @@ namespace Svg
                 // Skip to avoid double calculate Symbol element
                 // symbol element is only referenced by use element
                 // So here we need to skip when it is directly considered
-                if (child is Svg.Document_Structure.SvgSymbol)
+                if (child is SvgSymbol)
                     continue;
 
                 if (child is SvgVisualElement)

--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -6,7 +6,6 @@ using System.Drawing.Drawing2D;
 using System.Linq;
 using System.Reflection;
 using System.Xml;
-using Svg.DocumentStructure;
 using Svg.Transforms;
 
 namespace Svg

--- a/Source/SvgElementFactory.cs
+++ b/Source/SvgElementFactory.cs
@@ -22,9 +22,10 @@ namespace Svg
         {
             // cache ElementInfo in static Field
             var svgTypes = from t in typeof(SvgDocument).Assembly.GetExportedTypes()
-                where t.GetCustomAttributes(typeof(SvgElementAttribute), true).Length > 0
+                let attrs = (SvgElementAttribute[])t.GetCustomAttributes(typeof(SvgElementAttribute), true)
+                where attrs.Length > 0 && !string.IsNullOrWhiteSpace(attrs[0].ElementName)
                       && t.IsSubclassOf(typeof(SvgElement))
-                select new ElementInfo { ElementName = ((SvgElementAttribute)t.GetCustomAttributes(typeof(SvgElementAttribute), true)[0]).ElementName, ElementType = t };
+                select new ElementInfo { ElementName = attrs[0].ElementName, ElementType = t };
 
             availableElements = svgTypes.ToList();
 
@@ -264,8 +265,8 @@ namespace Svg
             return false;
         }
 #if !USE_SOURCE_GENERATORS
-        private static Dictionary<Type, Dictionary<string, PropertyDescriptorCollection>> _propertyDescriptors = new Dictionary<Type, Dictionary<string, PropertyDescriptorCollection>>();
-        private static object syncLock = new object();
+        private static readonly Dictionary<Type, Dictionary<string, PropertyDescriptorCollection>> _propertyDescriptors = new Dictionary<Type, Dictionary<string, PropertyDescriptorCollection>>();
+        private static readonly object syncLock = new object();
 #endif
         internal static bool SetPropertyValue(SvgElement element, string attributeName, string attributeValue, SvgDocument document, bool isStyle = false)
         {

--- a/Tests/Svg.UnitTests/SvgElementDeepCopyTest.cs
+++ b/Tests/Svg.UnitTests/SvgElementDeepCopyTest.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml;
-using Svg.Document_Structure;
+using Svg.DocumentStructure;
 using Svg.FilterEffects;
 
 namespace Svg.UnitTests

--- a/Tests/Svg.UnitTests/SvgElementDeepCopyTest.cs
+++ b/Tests/Svg.UnitTests/SvgElementDeepCopyTest.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml;
-using Svg.DocumentStructure;
 using Svg.FilterEffects;
 
 namespace Svg.UnitTests

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -3,6 +3,9 @@ The release versions are NuGet releases.
 
 ## Unreleased (master)
 
+### Changes
+* change namespace of SvgSymbol from Svg.Document_Structure to Svg. (see [PR #556](https://github.com/svg-net/SVG/pull/556))
+
 ### Enhancements
 * minimize XmlTextReader customization (see [PR #836](https://github.com/svg-net/SVG/pull/836))
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

ref. #93.

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

Only `Svg.Document_Structure`, **_**(underscore) is included in namespace.
So, change namespace without **_**(underscore).

I think `Svg.Symbol` is good.(like `SvgDefinitionList`, `SvgFragment` and `SvgGroup`.)
However, because there is a possibility of build error in existing environments, I decided on this namespace.

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
