### PR TITLE
Adapt documentation to changed URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ documentation updates.
 
 If you found a bug in SVG.NET, you can [create an issue](https://help.github.com/articles/creating-an-issue/).
 If you are able to build the library locally, please check, if the problem still exists in the
-[master branch](https://github.com/vvvv/SVG) before filing the bug. 
+[master branch](https://github.com/svg-net/SVG) before filing the bug. 
 If you can reproduce the problem, please provide enough information so that it can be reproduced by other developers.
 This includes:
   * The Operating System
@@ -28,7 +28,7 @@ Of course - implementing it yourself is the best chance to get it done!
 ### Contributing Code
 
 The preferred workflow for contributing code is to 
-[fork](https://help.github.com/articles/fork-a-repo/) the [repository](https://github.com/vvvv/SVG) on GitHub, clone it, 
+[fork](https://help.github.com/articles/fork-a-repo/) the [repository](https://github.com/svg-net/SVG) on GitHub, clone it, 
 develop on a feature branch, and [create a pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork) when done.
 There are a few things to consider for contributing code:
   * Please use the same coding style as in the rest of the code
@@ -44,6 +44,6 @@ There are a few things to consider for contributing code:
 
 This projects is in need of documentation - any help to add documentation infrastructure, 
 inline documentation, how-tos or sample code is appreciated!
-For specifics, please refer to the [issue related to documentation](https://github.com/vvvv/SVG/issues/401).
+For specifics, please refer to the [issue related to documentation](https://github.com/svg-net/SVG/issues/401).
 
 Thanks for taking the time to contribute to SVG.NET!

--- a/Nuget/Svg.nuspec
+++ b/Nuget/Svg.nuspec
@@ -7,7 +7,7 @@
         <authors>davescriven,jvenema,owaits,ddpruitt,Ralf1108,Tebjan Halm,and others</authors>
         <owners>vvvv.org</owners>
         <licenseUrl>http://opensource.org/licenses/MS-PL.html</licenseUrl>
-        <projectUrl>https://github.com/vvvv/SVG</projectUrl>
+        <projectUrl>https://github.com/svg-net/SVG</projectUrl>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <description>Public fork of the C# SVG rendering library on codeplex: https://svg.codeplex.com/
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Public fork of the C# SVG rendering library on codeplex: https://svg.codeplex.co
 This started out as a minor modification to enable the writing of proper SVG strings. But now after almost two years we have so many fixes and improvements that we decided to share our current codebase to the public in order to improve it even further.
 
 So please feel free to fork it and open pull requests for any fix, improvement or feature you add. 
-You may check the [contributing guide](https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md) for more information on how to do this. 
+You may check the [contributing guide](https://github.com/svg-net/SVG/blob/master/CONTRIBUTING.md) for more information on how to do this. 
 
-For information on installation and usage of the library, and for release notes please check the [documentation pages](http://vvvv.github.io/SVG/).
+For information on installation and usage of the library, and for release notes please check the [documentation pages](http://svg-net.github.io/SVG/).
 
 ## Projects using the library
 

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -32,7 +32,7 @@
       Supports multiple targets v4.5.2 thru to dotnetcore2.2.
       NetStandard does not fully support the Drawing2D package - so has been left out.
     </PackageReleaseNotes>
-    <PackageProjectUrl>https://github.com/vvvv/SVG</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/svg-net/SVG</PackageProjectUrl>
     <PackageIconUrl>https://www.w3.org/Icons/SVG/svg-logo-v.png</PackageIconUrl>
     <PackageIcon>svg-logo-v.png</PackageIcon>
     <LangVersion>latest</LangVersion>

--- a/Source/SvgNuget/Svg.Package.nuproj
+++ b/Source/SvgNuget/Svg.Package.nuproj
@@ -31,7 +31,7 @@ So please feel free to fork it and open pull requests for any fix, improvement o
 
 License: Microsoft Public License: https://svg.codeplex.com/license</Description>
     <ReleaseNotes>merged github pull requests</ReleaseNotes>
-    <ProjectUrl>https://github.com/vvvv/SVG</ProjectUrl>
+    <ProjectUrl>https://github.com/svg-net/SVG</ProjectUrl>
     <LicenseUrl>http://opensource.org/licenses/MS-PL.html</LicenseUrl>
     <Copyright>Copyright © vvvv.org</Copyright>
     <Tags>svg, vector graphics, rendering</Tags>

--- a/Source/SvgNuget/Svg.nuspec
+++ b/Source/SvgNuget/Svg.nuspec
@@ -7,7 +7,7 @@
         <authors>davescriven,jvenema,owaits,ddpruitt,Ralf1108,Tebjan Halm,and others</authors>
         <owners>vvvv.org</owners>
         <licenseUrl>http://opensource.org/licenses/MS-PL.html</licenseUrl>
-        <projectUrl>https://github.com/vvvv/SVG</projectUrl>
+        <projectUrl>https://github.com/svg-net/SVG</projectUrl>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <description>Public fork of the C# SVG rendering library on codeplex: https://svg.codeplex.com/
 

--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -49,7 +49,7 @@ dotnet build -c release -f netcoreapp2.2 Svg.csproj
 This will put the output into the `bin/Release/netcoreapp2.2/` folder.
 
 ## Special instructions for Mac and Linux
-The library depends on GDI+ (see also [here](http://vvvv.github.io/SVG/doc/Q&A.html#im-getting-a-svggdipluscannotbeloadedexception-if-running-under-linux-or-macos)) for rendering.
+The library depends on GDI+ (see also [here](http://svg-net.github.io/SVG/doc/Q&A.html#im-getting-a-svggdipluscannotbeloadedexception-if-running-under-linux-or-macos)) for rendering.
 .NET Core does not support GDI+ out of the box for non-Windows systems. For Mac and Linux you need to add a special compatibility package.
 This is not included in the packages by default, since this would break rendering on Windows systems.
 
@@ -102,8 +102,8 @@ The Svg library does not utilize other external references under Windows, and by
 However please keep in mind that the Mac and Linux versions require additional tooling/packages.
 
 ## Using the library (examples)
-This part will be extended in the future, for now please refer to the [Q&A](http://vvvv.github.io/SVG/doc/Q&A.html) for examples of how to use the library.
+This part will be extended in the future, for now please refer to the [Q&A](http://svg-net.github.io/SVG/doc/Q&A.html) for examples of how to use the library.
 
 ## Troubleshooting
-If you encounter any problems or difficulties, please refer to the [Q&A part of the documentation](http://vvvv.github.io/SVG/doc/Q&A.html).
+If you encounter any problems or difficulties, please refer to the [Q&A part of the documentation](http://svg-net.github.io/SVG/doc/Q&A.html).
 If the Q&A does not solve your problem, please open a ticket with your request.

--- a/doc/Q&A.md
+++ b/doc/Q&A.md
@@ -2,11 +2,11 @@ This is currently a collection of answered questions in issues that have been cl
 The format of the page is preliminary and maybe changed if more questions accumulate.
 
 ## How to get started
-Please use our [getting started article](http://vvvv.github.io/SVG/doc/GettingStarted.html) to get started with installation and implementation of the SVG library.
+Please use our [getting started article](http://svg-net.github.io/SVG/doc/GettingStarted.html) to get started with installation and implementation of the SVG library.
 
 ## How to re-render an SVG faster?
 
-(from [#327](https://github.com/vvvv/SVG/issues/327), by @flemingtech)
+(from [#327](https://github.com/svg-net/SVG/issues/327), by @flemingtech)
 
 The rendering type plays a significant roll on rendering speeds. For example, it anti-aliasing is off for the SvgDocument render times are notably faster.
 
@@ -18,13 +18,13 @@ Once I'm done, I render the first SVG to an Image. When any of the 'animating' e
 
 ## Can I use SVG.NET in a UWP Windows 10 App?
 
-(from [#219](https://github.com/vvvv/SVG/issues/219), by @jonthysell)
+(from [#219](https://github.com/svg-net/SVG/issues/219), by @jonthysell)
 
 SVG.NET requires the System.Drawing namespace, which is not available in UWP. See http://stackoverflow.com/questions/31545389/windows-universal-app-with-system-drawing-and-possible-alternative.
 
 ## How to render an SVG image to a single-color bitmap image?
 
-(from [#366](https://github.com/vvvv/SVG/issues/366), by @UweKeim)
+(from [#366](https://github.com/svg-net/SVG/issues/366), by @UweKeim)
 
 I was able to find a solution with the following fragment:
 
@@ -56,7 +56,7 @@ private void processNodes(IEnumerable<SvgElement> nodes, SvgPaintServer colorSer
 
 ## How to render only a specific SvgElement?
 
-(from [#403](https://github.com/vvvv/SVG/issues/403), by @ievgennaida)
+(from [#403](https://github.com/svg-net/SVG/issues/403), by @ievgennaida)
 
 Use `element.RenderElement();`.
 
@@ -66,7 +66,7 @@ Use `SvgDocument.Draw(int rasterWidth, int rasterHeight)`. If one of the values 
 
 ## Is this code server-safe?
 
-(from [#381](https://github.com/vvvv/SVG/issues/381), by @rangercej, answered by @gvheertum)
+(from [#381](https://github.com/svg-net/SVG/issues/381), by @rangercej, answered by @gvheertum)
 
 I used it in server side code (ASP.NET MVC application and API's) and never had any problems with it. There is however be possible issues regarding use in services and API's, for example the System.Drawing might not always be available in certain situations (if I am not mistaken, some Azure service will not provide the System.Drawing since it relies on GDI calls) and will also be an issue when using it as "portable" code for example in .NET standard or .NET core (but I believe the library is already working on a migration/compatibility with .NET core/standard).
 
@@ -78,7 +78,7 @@ I believe there are some parallelisation tests in the UnitTest suite, since the 
 
 ## How to change the SvgUnit DPI?
 
-(from [#313](https://github.com/vvvv/SVG/issues/313), by @KieranSmartMP)
+(from [#313](https://github.com/svg-net/SVG/issues/313), by @KieranSmartMP)
 
 `SvgUnit` takes the DPI (which is called `Ppi` here) from the document. This is set to the system DPI at creation time, but can be set to another value afterwards, e.g. 
 ```c#
@@ -89,13 +89,13 @@ I believe there are some parallelisation tests in the UnitTest suite, since the 
 
 ## Why does my application crash with "cannot allocate the required memory"?
 
-(from [#250](https://github.com/vvvv/SVG/issues/250), by @Radzhab)
+(from [#250](https://github.com/svg-net/SVG/issues/250), by @Radzhab)
 
 If you try to open a very large SVG file in your application, it may crash, because .NET refuses to allocate that much contiguous memory, even if it could do so in theory. This is done to avoid processes to consume too much memory and slow down the system. Nothing we can do about this - you may catch this exception in your application and inform the user, or try to resize your SVG document and retry.
 
 ## How to add a custom attribute to an SVG element?
 
-(from [#481](https://github.com/vvvv/SVG/issues/481), by @lroye)
+(from [#481](https://github.com/svg-net/SVG/issues/481), by @lroye)
 
 Custom attributes are publicly accessible as a collection, you can add an attribute like this:
 ```C#
@@ -104,7 +104,7 @@ Custom attributes are publicly accessible as a collection, you can add an attrib
 
 ## I'm getting a SvgGdiPlusCannotBeLoadedException if running under Linux or MacOs
 
-(see [#494](https://github.com/vvvv/SVG/pull/495#issuecomment-505429874), by @ErlendSB)
+(see [#494](https://github.com/svg-net/SVG/pull/495#issuecomment-505429874), by @ErlendSB)
 
 This happens if libgdiplus is not installed under Linux or MacOs - libgdiplus is need for the implementation of System.Drawing.Common. The system will validate gdi+ capabilities when calling SvgDocument.Open(), if the gdi+ capabilities are not available, you will receive a SvgGdiPlusCannotBeLoadedException. 
 

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -4,18 +4,18 @@ The release versions are NuGet releases.
 ## Unreleased (master)
 
 ### Enhancements
-* implement font-weight bolder and lighter (see [PR #727](https://github.com/vvvv/SVG/pull/727))
-* check if BaseUri is absolute (see [PR #738](https://github.com/vvvv/SVG/pull/738))
+* implement font-weight bolder and lighter (see [PR #727](https://github.com/svg-net/SVG/pull/727))
+* check if BaseUri is absolute (see [PR #738](https://github.com/svg-net/SVG/pull/738))
 * added support for `miter-clip` and `arcs` line joins, and for `fr` radial gradiant property
-  (SVG2 features, see [PR #621](https://github.com/vvvv/SVG/pull/621))
+  (SVG2 features, see [PR #621](https://github.com/svg-net/SVG/pull/621))
 
 ### Fixes
-* fixed filter Inherited (see [#541](https://github.com/vvvv/SVG/issues/541) and [PR #689](https://github.com/vvvv/SVG/pull/689))
-* fixed calculate required layout rectangle (see [#732](https://github.com/vvvv/SVG/issues/732) and [PR #741](https://github.com/vvvv/SVG/pull/741))
-* fixed the parsing of significant whitespace (see [#744](https://github.com/vvvv/SVG/issues/744) and [PR #745](https://github.com/vvvv/SVG/pull/745))
-* fixed build error in .NET Standard 2.1 (see [#746](https://github.com/vvvv/SVG/issues/746) and [PR #750](https://github.com/vvvv/SVG/pull/750))
-* fixed opacity issue (see [#747](https://github.com/vvvv/SVG/issues/747) and [PR #751](https://github.com/vvvv/SVG/pull/751))
-* fixed bounds calculation in polygon (see [#758](https://github.com/vvvv/SVG/issues/758) and [PR #759](https://github.com/vvvv/SVG/pull/759))
+* fixed filter Inherited (see [#541](https://github.com/svg-net/SVG/issues/541) and [PR #689](https://github.com/svg-net/SVG/pull/689))
+* fixed calculate required layout rectangle (see [#732](https://github.com/svg-net/SVG/issues/732) and [PR #741](https://github.com/svg-net/SVG/pull/741))
+* fixed the parsing of significant whitespace (see [#744](https://github.com/svg-net/SVG/issues/744) and [PR #745](https://github.com/svg-net/SVG/pull/745))
+* fixed build error in .NET Standard 2.1 (see [#746](https://github.com/svg-net/SVG/issues/746) and [PR #750](https://github.com/svg-net/SVG/pull/750))
+* fixed opacity issue (see [#747](https://github.com/svg-net/SVG/issues/747) and [PR #751](https://github.com/svg-net/SVG/pull/751))
+* fixed bounds calculation in polygon (see [#758](https://github.com/svg-net/SVG/issues/758) and [PR #759](https://github.com/svg-net/SVG/pull/759))
 * make sure that paths with a single `moveto` command don't display line caps
  (see [#634](https://github.com/vvvv/SVG/issues/634)
 * fixed rendering of text-anchor `middle` (see [#769](https://github.com/vvvv/SVG/issues/769)
@@ -24,38 +24,38 @@ The release versions are NuGet releases.
 ## [Version 3.1.1](https://www.nuget.org/packages/Svg/3.1.1)
 
 ### Enhancements
-* added new filter effects classes (see [PR #641](https://github.com/vvvv/SVG/pull/641))
-* added FilterUnits and PrimitiveUnits properties to SvgFilter class (see [PR #641](https://github.com/vvvv/SVG/pull/641))
-* added X, Y, Width and Height properties to SvgFilterPrimitive class (see [PR #641](https://github.com/vvvv/SVG/pull/641))
-* added SvgNumberCollection data type similar to SvgPointCollection (see [PR #641](https://github.com/vvvv/SVG/pull/641))
-* added MaskUnits, MaskContentUnits, X, Y, Width and Height properties to SvgMask (see [PR #654](https://github.com/vvvv/SVG/pull/654))
-* added FontStretch property to SvgElement (see [PR #654](https://github.com/vvvv/SVG/pull/654))
-* moved ColorInterpolationFilters property to SvgElement because its a presentation attribute (see [PR #667](https://github.com/vvvv/SVG/pull/667))
-* added ColorInterpolation property to SvgElement (see [PR #667](https://github.com/vvvv/SVG/pull/667))
-* added Href property to SvgFilter (see [PR #679](https://github.com/vvvv/SVG/pull/679))
-* supports localized family names (see [PR #706](https://github.com/vvvv/SVG/pull/706))
+* added new filter effects classes (see [PR #641](https://github.com/svg-net/SVG/pull/641))
+* added FilterUnits and PrimitiveUnits properties to SvgFilter class (see [PR #641](https://github.com/svg-net/SVG/pull/641))
+* added X, Y, Width and Height properties to SvgFilterPrimitive class (see [PR #641](https://github.com/svg-net/SVG/pull/641))
+* added SvgNumberCollection data type similar to SvgPointCollection (see [PR #641](https://github.com/svg-net/SVG/pull/641))
+* added MaskUnits, MaskContentUnits, X, Y, Width and Height properties to SvgMask (see [PR #654](https://github.com/svg-net/SVG/pull/654))
+* added FontStretch property to SvgElement (see [PR #654](https://github.com/svg-net/SVG/pull/654))
+* moved ColorInterpolationFilters property to SvgElement because its a presentation attribute (see [PR #667](https://github.com/svg-net/SVG/pull/667))
+* added ColorInterpolation property to SvgElement (see [PR #667](https://github.com/svg-net/SVG/pull/667))
+* added Href property to SvgFilter (see [PR #679](https://github.com/svg-net/SVG/pull/679))
+* supports localized family names (see [PR #706](https://github.com/svg-net/SVG/pull/706))
 
 ### Fixes
-* fixed CoordinateParser handling of invalid state (see [PR #640](https://github.com/vvvv/SVG/pull/640))
-* fixed CoordinateParser handling of invalid state (see [PR #642](https://github.com/vvvv/SVG/pull/642))
-* set correct default values for SvgFilter properties (see [PR #641](https://github.com/vvvv/SVG/pull/641))
-* dispose Matrix in SvgFilter (see [PR #644](https://github.com/vvvv/SVG/pull/644))
-* dispose resources in ImageBuffer (see [PR #646](https://github.com/vvvv/SVG/pull/646))
-* fixed StdDeviation property type of the SvgGaussianBlur class (see [PR #648](https://github.com/vvvv/SVG/pull/648))
-* fixed Providing entities in SvgDocument.Open does not work (see [#651](https://github.com/vvvv/SVG/issues/651))
-* fixed initial values of attributes related to text (see [PR #655](https://github.com/vvvv/SVG/pull/655))
-* fixed 'inherit' does not work at visibility and display (see [PR #656](https://github.com/vvvv/SVG/pull/656))
-* fixed Won't display gradients if they're wider than 698 px (see [#252](https://github.com/vvvv/SVG/issues/252) and [PR #658](https://github.com/vvvv/SVG/pull/658))
-* fixed 'clip-rule' attribute. (see [PR #662](https://github.com/vvvv/SVG/pull/662))
-* fixed SvgFontStyle values (see [PR #661](https://github.com/vvvv/SVG/pull/661))
-* fixed EnumConverters (see [PR #663](https://github.com/vvvv/SVG/pull/663))
-* fixed Parameter is not valid (see [#664](https://github.com/vvvv/SVG/issues/664) and [PR #665](https://github.com/vvvv/SVG/pull/665))
-* fixed Endless loop and out of memory on a specific file (see [#675](https://github.com/vvvv/SVG/issues/675) and [PR #681](https://github.com/vvvv/SVG/pull/681))
-* fixed 'none' does not work at clip-path and filter (see [PR #686](https://github.com/vvvv/SVG/pull/686))
-* fixed argument of Path method (see [PR #690](https://github.com/vvvv/SVG/pull/690))
-* fixed w3c example styling-css-08-f (see [PR #692](https://github.com/vvvv/SVG/pull/692))
-* fixed Output namespace in inner `<svg>` element (see [PR #702](https://github.com/vvvv/SVG/pull/702))
-* fixed SvgNodeReader does not resolve entity reference (see [#707](https://github.com/vvvv/SVG/issues/707) and [PR #713](https://github.com/vvvv/SVG/pull/713))
+* fixed CoordinateParser handling of invalid state (see [PR #640](https://github.com/svg-net/SVG/pull/640))
+* fixed CoordinateParser handling of invalid state (see [PR #642](https://github.com/svg-net/SVG/pull/642))
+* set correct default values for SvgFilter properties (see [PR #641](https://github.com/svg-net/SVG/pull/641))
+* dispose Matrix in SvgFilter (see [PR #644](https://github.com/svg-net/SVG/pull/644))
+* dispose resources in ImageBuffer (see [PR #646](https://github.com/svg-net/SVG/pull/646))
+* fixed StdDeviation property type of the SvgGaussianBlur class (see [PR #648](https://github.com/svg-net/SVG/pull/648))
+* fixed Providing entities in SvgDocument.Open does not work (see [#651](https://github.com/svg-net/SVG/issues/651))
+* fixed initial values of attributes related to text (see [PR #655](https://github.com/svg-net/SVG/pull/655))
+* fixed 'inherit' does not work at visibility and display (see [PR #656](https://github.com/svg-net/SVG/pull/656))
+* fixed Won't display gradients if they're wider than 698 px (see [#252](https://github.com/svg-net/SVG/issues/252) and [PR #658](https://github.com/svg-net/SVG/pull/658))
+* fixed 'clip-rule' attribute. (see [PR #662](https://github.com/svg-net/SVG/pull/662))
+* fixed SvgFontStyle values (see [PR #661](https://github.com/svg-net/SVG/pull/661))
+* fixed EnumConverters (see [PR #663](https://github.com/svg-net/SVG/pull/663))
+* fixed Parameter is not valid (see [#664](https://github.com/svg-net/SVG/issues/664) and [PR #665](https://github.com/svg-net/SVG/pull/665))
+* fixed Endless loop and out of memory on a specific file (see [#675](https://github.com/svg-net/SVG/issues/675) and [PR #681](https://github.com/svg-net/SVG/pull/681))
+* fixed 'none' does not work at clip-path and filter (see [PR #686](https://github.com/svg-net/SVG/pull/686))
+* fixed argument of Path method (see [PR #690](https://github.com/svg-net/SVG/pull/690))
+* fixed w3c example styling-css-08-f (see [PR #692](https://github.com/svg-net/SVG/pull/692))
+* fixed Output namespace in inner `<svg>` element (see [PR #702](https://github.com/svg-net/SVG/pull/702))
+* fixed SvgNodeReader does not resolve entity reference (see [#707](https://github.com/svg-net/SVG/issues/707) and [PR #713](https://github.com/svg-net/SVG/pull/713))
 
 ## [Version 3.0.102](https://www.nuget.org/packages/Svg/3.0.102)
 
@@ -64,13 +64,13 @@ The release versions are NuGet releases.
 * upgraded the used Fizzler libary to 1.2.0 (supports Netstandard 1.0 and 2.0)
 
 ### Enhancements
-* check that there is a `moveto` command at the beginning of a path (see [PR #616](https://github.com/vvvv/SVG/pull/616))
-* add support for `<a>` element (see [#626](https://github.com/vvvv/SVG/issues/626) and [PR #628](https://github.com/vvvv/SVG/pull/628)))
-* added ColorConverter from dotnet runtime codebase to make Netstandard 2.0 target more complete (see [PR #630](https://github.com/vvvv/SVG/pull/630))
+* check that there is a `moveto` command at the beginning of a path (see [PR #616](https://github.com/svg-net/SVG/pull/616))
+* add support for `<a>` element (see [#626](https://github.com/svg-net/SVG/issues/626) and [PR #628](https://github.com/svg-net/SVG/pull/628)))
+* added ColorConverter from dotnet runtime codebase to make Netstandard 2.0 target more complete (see [PR #630](https://github.com/svg-net/SVG/pull/630))
 
 ### Fixes
-* fixed nested svg tags not rendered properly (see [#622](https://github.com/vvvv/SVG/issues/622))
-* added handling of invalid property in parser (see [#632](https://github.com/vvvv/SVG/issues/632))
+* fixed nested svg tags not rendered properly (see [#622](https://github.com/svg-net/SVG/issues/622))
+* added handling of invalid property in parser (see [#632](https://github.com/svg-net/SVG/issues/632))
 
 ## [Version 3.0.84](https://www.nuget.org/packages/Svg/3.0.84)
 
@@ -81,10 +81,10 @@ _**Note:**_
   this can be safely ignored and will be gone in the next version
  
 ### Enhancements
-* added preliminary support for .NET Standard 2.0 (see [#346](https://github.com/vvvv/SVG/issues/346));
+* added preliminary support for .NET Standard 2.0 (see [#346](https://github.com/svg-net/SVG/issues/346));
   Drawing2D is not fully supported
-* added support for href namespace (see [PR #579](https://github.com/vvvv/SVG/pull/579)) 
-* support non-standard mime types for embedded images (see [#578](https://github.com/vvvv/SVG/issues/578))
+* added support for href namespace (see [PR #579](https://github.com/svg-net/SVG/pull/579)) 
+* support non-standard mime types for embedded images (see [#578](https://github.com/svg-net/SVG/issues/578))
 
 ### Infrastructure
 * the Fizzler library is now included via NuGet instead of copying the sources
@@ -95,10 +95,10 @@ _**Note:**_
 * added auto-generated API documentation
 
 ### Fixes
-* fixed scaling of embedded images (see [#592](https://github.com/vvvv/SVG/issues/592))
-* fixed issue for stroke dasharray with odd number of values (see [PR #584](https://github.com/vvvv/SVG/pull/584)) 
-* fixed parsing of some color attributes (see [PR #580](https://github.com/vvvv/SVG/pull/580)) 
-* fixed behavior of 'Inherit' value for several attributes (see [#541](https://github.com/vvvv/SVG/issues/541))
+* fixed scaling of embedded images (see [#592](https://github.com/svg-net/SVG/issues/592))
+* fixed issue for stroke dasharray with odd number of values (see [PR #584](https://github.com/svg-net/SVG/pull/584)) 
+* fixed parsing of some color attributes (see [PR #580](https://github.com/svg-net/SVG/pull/580)) 
+* fixed behavior of 'Inherit' value for several attributes (see [#541](https://github.com/svg-net/SVG/issues/541))
 
 
 ## [Version 3.0.49](https://www.nuget.org/packages/Svg/3.0.49)
@@ -107,16 +107,16 @@ _**Note:**_
 To build it yourself, you need at least Visual Studio 2017 due to the added multi-platform support.
 
 ### Enhancements
-* added support for .NET Core 2.2 (see PR [#448](https://github.com/vvvv/SVG/pull/448))
-* handle missing gdi+ library on MacOs or Linux by a descriptive exception (see [#501](https://github.com/vvvv/SVG/issues/501))
-* allow ID start with a number (see [#138](https://github.com/vvvv/SVG/issues/138))
-* added support for embedded SVG in data URIs (see [#71](https://github.com/vvvv/SVG/issues/71)
-  and [#220](https://github.com/vvvv/SVG/issues/220))
-* support `auto-start-reverse` value for marker orientation (see PR [#458](https://github.com/vvvv/SVG/pull/458)) 
-* added support for the SvgScript tag (see [PR #558](https://github.com/vvvv/SVG/pull/558)) 
+* added support for .NET Core 2.2 (see PR [#448](https://github.com/svg-net/SVG/pull/448))
+* handle missing gdi+ library on MacOs or Linux by a descriptive exception (see [#501](https://github.com/svg-net/SVG/issues/501))
+* allow ID start with a number (see [#138](https://github.com/svg-net/SVG/issues/138))
+* added support for embedded SVG in data URIs (see [#71](https://github.com/svg-net/SVG/issues/71)
+  and [#220](https://github.com/svg-net/SVG/issues/220))
+* support `auto-start-reverse` value for marker orientation (see PR [#458](https://github.com/svg-net/SVG/pull/458)) 
+* added support for the SvgScript tag (see [PR #558](https://github.com/svg-net/SVG/pull/558)) 
 
 ### Infrastructure
-* use NUnit instead of MSTest for unit tests (see [#420](https://github.com/vvvv/SVG/issues/420))
+* use NUnit instead of MSTest for unit tests (see [#420](https://github.com/svg-net/SVG/issues/420))
 * added automatic git versioning
 * xml documentation is included in the nuget package
 
@@ -125,86 +125,86 @@ To build it yourself, you need at least Visual Studio 2017 due to the added mult
 
 ### Fixes
 
-* added check for invalid bounds (see [#554](https://github.com/vvvv/SVG/issues/554))
-* added support for "Grey" color (see [PR #551](https://github.com/vvvv/SVG/pull/551)) 
-* updated core compat package to resolve font issues on Mac (see [#548](https://github.com/vvvv/SVG/issues/548))
-* fixed parsing of white spaces in color matrix (see [PR #540](https://github.com/vvvv/SVG/pull/540))
-* fixed zero matrix transformation issues (see [PR #537](https://github.com/vvvv/SVG/pull/537))
-* avoid adding a null system font (see [#528](https://github.com/vvvv/SVG/issues/528))
-* fixed missing text drawing (see [#84](https://github.com/vvvv/SVG/issues/84))
-* fixed y2 default value for SvgLinearGradientServer (see [PR #530](https://github.com/vvvv/SVG/pull/530))
+* added check for invalid bounds (see [#554](https://github.com/svg-net/SVG/issues/554))
+* added support for "Grey" color (see [PR #551](https://github.com/svg-net/SVG/pull/551)) 
+* updated core compat package to resolve font issues on Mac (see [#548](https://github.com/svg-net/SVG/issues/548))
+* fixed parsing of white spaces in color matrix (see [PR #540](https://github.com/svg-net/SVG/pull/540))
+* fixed zero matrix transformation issues (see [PR #537](https://github.com/svg-net/SVG/pull/537))
+* avoid adding a null system font (see [#528](https://github.com/svg-net/SVG/issues/528))
+* fixed missing text drawing (see [#84](https://github.com/svg-net/SVG/issues/84))
+* fixed y2 default value for SvgLinearGradientServer (see [PR #530](https://github.com/svg-net/SVG/pull/530))
 * fixed incorrect parsing of some float values for non-English cultures
-  (see [PR #525](https://github.com/vvvv/SVG/pull/525) and [#526](https://github.com/vvvv/SVG/pull/526))
-* fixed pattern drawing (see [#280](https://github.com/vvvv/SVG/issues/280))
-* prevent crash on reading entities (see [#518](https://github.com/vvvv/SVG/issues/518))
-* fixed saving of attributes with default value (see [PR #520](https://github.com/vvvv/SVG/pull/520))
-* fixed determination of OS type (see [PR #517](https://github.com/vvvv/SVG/pull/517))
-* fixed writing of custom style attributes (see [#507](https://github.com/vvvv/SVG/issues/507))
-* handle overlapping caps by joining the lines (see [#508](https://github.com/vvvv/SVG/issues/508))
-* correctly handle style attributes in top level svg element (see [#391](https://github.com/vvvv/SVG/issues/391))
-* fixed incorrect rendering if stroke-dasharray value is none (see [PR #504](https://github.com/vvvv/SVG/pull/504))
-* prevent exception for zero bounds and opacity not one (see [#479](https://github.com/vvvv/SVG/issues/479))
-* make sure mask elements are written back to svg (see [#271](https://github.com/vvvv/SVG/issues/271))
-* fixed incorrect clip region (see [#363](https://github.com/vvvv/SVG/issues/363))
-* fixed overflow error on 1 character text with tspan (see [#488](https://github.com/vvvv/SVG/issues/488))
-* fixed crash with unsupported pseudo classes (see [#315](https://github.com/vvvv/SVG/issues/315))
-* fixes wrong text position in some scenarios (see PR [#475](https://github.com/vvvv/SVG/pull/475))
-* fixed handling of spaces for `xml:space="default"` (see PR [#471](https://github.com/vvvv/SVG/pull/471))
-* fixed crash if more than font have the same name (see [#452](https://github.com/vvvv/SVG/issues/452))
+  (see [PR #525](https://github.com/svg-net/SVG/pull/525) and [#526](https://github.com/svg-net/SVG/pull/526))
+* fixed pattern drawing (see [#280](https://github.com/svg-net/SVG/issues/280))
+* prevent crash on reading entities (see [#518](https://github.com/svg-net/SVG/issues/518))
+* fixed saving of attributes with default value (see [PR #520](https://github.com/svg-net/SVG/pull/520))
+* fixed determination of OS type (see [PR #517](https://github.com/svg-net/SVG/pull/517))
+* fixed writing of custom style attributes (see [#507](https://github.com/svg-net/SVG/issues/507))
+* handle overlapping caps by joining the lines (see [#508](https://github.com/svg-net/SVG/issues/508))
+* correctly handle style attributes in top level svg element (see [#391](https://github.com/svg-net/SVG/issues/391))
+* fixed incorrect rendering if stroke-dasharray value is none (see [PR #504](https://github.com/svg-net/SVG/pull/504))
+* prevent exception for zero bounds and opacity not one (see [#479](https://github.com/svg-net/SVG/issues/479))
+* make sure mask elements are written back to svg (see [#271](https://github.com/svg-net/SVG/issues/271))
+* fixed incorrect clip region (see [#363](https://github.com/svg-net/SVG/issues/363))
+* fixed overflow error on 1 character text with tspan (see [#488](https://github.com/svg-net/SVG/issues/488))
+* fixed crash with unsupported pseudo classes (see [#315](https://github.com/svg-net/SVG/issues/315))
+* fixes wrong text position in some scenarios (see PR [#475](https://github.com/svg-net/SVG/pull/475))
+* fixed handling of spaces for `xml:space="default"` (see PR [#471](https://github.com/svg-net/SVG/pull/471))
+* fixed crash if more than font have the same name (see [#452](https://github.com/svg-net/SVG/issues/452))
 * fixed rendering bug for text on path using very large font
-  (see PR [#468](https://github.com/vvvv/SVG/pull/468))
-* avoid exception in nested SVGs without size (see [#460](https://github.com/vvvv/SVG/issues/460))
+  (see PR [#468](https://github.com/svg-net/SVG/pull/468))
+* avoid exception in nested SVGs without size (see [#460](https://github.com/svg-net/SVG/issues/460))
 * fixed default input values for filter primitives
 * fixed parsing of float values in color matrixes and colors on non-English systems
-* fixed xlink:href value format (see PR [#455](https://github.com/vvvv/SVG/pull/455))
-* support various formats of URL string (see PR [#454](https://github.com/vvvv/SVG/pull/454))
+* fixed xlink:href value format (see PR [#455](https://github.com/svg-net/SVG/pull/455))
+* support various formats of URL string (see PR [#454](https://github.com/svg-net/SVG/pull/454))
 * fixed stack overflow crash on images with relative size 
-  (see [#436](https://github.com/vvvv/SVG/issues/436))
+  (see [#436](https://github.com/svg-net/SVG/issues/436))
 
 ## [Version 2.4.3](https://www.nuget.org/packages/Svg/2.4.3)
 ### Fixes
-* fixed boundary drawing with corner and stroke (see PR [#444](https://github.com/vvvv/SVG/pull/444))
-* fixed rendering with fill opacity 0 (see [#437](https://github.com/vvvv/SVG/issues/437))
-* fixed opacity attribute (see PR [#433](https://github.com/vvvv/SVG/pull/433))
-* fixed bounds calculation with stroke (see PR [#433](https://github.com/vvvv/SVG/pull/433))
+* fixed boundary drawing with corner and stroke (see PR [#444](https://github.com/svg-net/SVG/pull/444))
+* fixed rendering with fill opacity 0 (see [#437](https://github.com/svg-net/SVG/issues/437))
+* fixed opacity attribute (see PR [#433](https://github.com/svg-net/SVG/pull/433))
+* fixed bounds calculation with stroke (see PR [#433](https://github.com/svg-net/SVG/pull/433))
 
 ## [Version 2.4.2](https://www.nuget.org/packages/Svg/2.4.2)
 ### Enhancements
 * added font manager to allow user-defined font handling 
-  (see PR [#414](https://github.com/vvvv/SVG/pull/414)) 
+  (see PR [#414](https://github.com/svg-net/SVG/pull/414)) 
 
 ### Fixes
-* fixed handling of invalid hex color and whitespace after hex color (see [#399](https://github.com/vvvv/SVG/issues/399))
-* fixed default font size (caused text not to be displayed, see [#419](https://github.com/vvvv/SVG/issues/419))
-* fixed writing of RGBA colors (see [#129](https://github.com/vvvv/SVG/issues/129))
-* fixed writing of custom styles (see [#129](https://github.com/vvvv/SVG/issues/129))
-* fixed handling of default values for radial gradients (see [#397](https://github.com/vvvv/SVG/issues/397))
-* allow empty value for style property (see [#318](https://github.com/vvvv/SVG/issues/318))
+* fixed handling of invalid hex color and whitespace after hex color (see [#399](https://github.com/svg-net/SVG/issues/399))
+* fixed default font size (caused text not to be displayed, see [#419](https://github.com/svg-net/SVG/issues/419))
+* fixed writing of RGBA colors (see [#129](https://github.com/svg-net/SVG/issues/129))
+* fixed writing of custom styles (see [#129](https://github.com/svg-net/SVG/issues/129))
+* fixed handling of default values for radial gradients (see [#397](https://github.com/svg-net/SVG/issues/397))
+* allow empty value for style property (see [#318](https://github.com/svg-net/SVG/issues/318))
 * added handling of referenced viewBox scaling in "use" elements 
 * handle special case where path consists of a single move command 
-  (see [#223](https://github.com/vvvv/SVG/issues/223))
+  (see [#223](https://github.com/svg-net/SVG/issues/223))
 * correctly write fill-rule, clip-rule and named color attributes as lower case
-  (see [#272](https://github.com/vvvv/SVG/issues/272))
+  (see [#272](https://github.com/svg-net/SVG/issues/272))
 * several fixes for markers:
   * added support for marker attributes in groups
   * partly fixed marker appearance (stroke and fill color, scaling, deafult orientation)
-  * apply transformations in the marker drawing element (see [#215](https://github.com/vvvv/SVG/issues/215))
+  * apply transformations in the marker drawing element (see [#215](https://github.com/svg-net/SVG/issues/215))
   * correctly show mid markers for paths with Bezier curves
   * handle markers on paths with successive equal points
 
 ## [Version 2.4.1](https://www.nuget.org/packages/Svg/2.4.1)
 ### Changes
 * `ExCSS` lives now in the `Svg` namespace to avoid namespace collusions 
-  (see [#408](https://github.com/vvvv/SVG/issues/408))
+  (see [#408](https://github.com/svg-net/SVG/issues/408))
 
 ### Fixes
-* fixed handling of url IDs enclosed in apostrophes (see [#345](https://github.com/vvvv/SVG/issues/345)) 
-* fixed calculation of percentage values (PR [#410](https://github.com/vvvv/SVG/pull/410))
+* fixed handling of url IDs enclosed in apostrophes (see [#345](https://github.com/svg-net/SVG/issues/345)) 
+* fixed calculation of percentage values (PR [#410](https://github.com/svg-net/SVG/pull/410))
 * regression: missing scaling if rendering into a bitmap with defined size 
-  (see [#405](https://github.com/vvvv/SVG/issues/405))
-* consider transformation for all svg element bounds (see [#331](https://github.com/vvvv/SVG/issues/331))
-* prevent crash if `use` element has no reference (see [#323](https://github.com/vvvv/SVG/issues/323))
-* fixed handling of `fill=currentColor` (see [#398](https://github.com/vvvv/SVG/issues/398))
+  (see [#405](https://github.com/svg-net/SVG/issues/405))
+* consider transformation for all svg element bounds (see [#331](https://github.com/svg-net/SVG/issues/331))
+* prevent crash if `use` element has no reference (see [#323](https://github.com/svg-net/SVG/issues/323))
+* fixed handling of `fill=currentColor` (see [#398](https://github.com/svg-net/SVG/issues/398))
 
 ## [Version 2.4.0](https://www.nuget.org/packages/Svg/2.4.0)
 
@@ -213,20 +213,20 @@ To build it yourself, you need at least Visual Studio 2017 due to the added mult
   * added optional size parameter to `SvgDocument.Draw()`
   * allow relative paths for image URLs
   * improved path drawing performance
-  * added XML Header to conform according to SVG spec ([PR #269](https://github.com/vvvv/SVG/pull/269))
-  * added support for removing Byte Order Mark (BOM) ([PR #269](https://github.com/vvvv/SVG/pull/269))
+  * added XML Header to conform according to SVG spec ([PR #269](https://github.com/svg-net/SVG/pull/269))
+  * added support for removing Byte Order Mark (BOM) ([PR #269](https://github.com/svg-net/SVG/pull/269))
 
 ### Infrastructure
   * added copy of license
   * added automatic unit test execution after check-in in AppVeyor
 
 ### Fixes
-  * fixed display of rounded caps for dashed lines using dasharray (see [#191](https://github.com/vvvv/SVG/issues/191))
-  * fixed calculation of percentage units in 'y' (see [#329](https://github.com/vvvv/SVG/issues/329))
-  * fixed calculation of percentage units in `stroke-width` (see [#338](https://github.com/vvvv/SVG/issues/338))
-  * fixed display of `dasharray` with odd number (see [#58](https://github.com/vvvv/SVG/issues/58))
-  * fixed font alignment for "middle" and "end" (see [#385](https://github.com/vvvv/SVG/issues/385))
-  * fixed handling of `stroke-dashoffset` (see [#388](https://github.com/vvvv/SVG/issues/388))
+  * fixed display of rounded caps for dashed lines using dasharray (see [#191](https://github.com/svg-net/SVG/issues/191))
+  * fixed calculation of percentage units in 'y' (see [#329](https://github.com/svg-net/SVG/issues/329))
+  * fixed calculation of percentage units in `stroke-width` (see [#338](https://github.com/svg-net/SVG/issues/338))
+  * fixed display of `dasharray` with odd number (see [#58](https://github.com/svg-net/SVG/issues/58))
+  * fixed font alignment for "middle" and "end" (see [#385](https://github.com/svg-net/SVG/issues/385))
+  * fixed handling of `stroke-dashoffset` (see [#388](https://github.com/svg-net/SVG/issues/388))
   * fixed font shorthand parsing
   * fixed case insensitive enum parsing
   * ignore cycles in `use` elements to prevent crash
@@ -234,18 +234,18 @@ To build it yourself, you need at least Visual Studio 2017 due to the added mult
   * corrected DPI calculation to fix text positioning for printing 
   * ignore `textLength` attribute if X attribute is list
   * fixed drawing of SvgFont objects
-  * fixed adjustment if `lengthAdjust='spacingAndGlyphs'` (see [#373](https://github.com/vvvv/SVG/issues/373))
+  * fixed adjustment if `lengthAdjust='spacingAndGlyphs'` (see [#373](https://github.com/svg-net/SVG/issues/373))
   * fixed SvgAttribute reflection for .Net core
   * fixed default value for `preserveAspectRatio` attribute 
   * fixed path parsing mistaking 'E' as a command instead of an exponent
   * fixed image opacity
   * fixed usage of `ms colortranslator` class
   * fixed inproper use of UTF8Encoding
-  * fixed runtime error after accessing added `SvgText` element (see [#332](https://github.com/vvvv/SVG/issues/332)) 
+  * fixed runtime error after accessing added `SvgText` element (see [#332](https://github.com/svg-net/SVG/issues/332)) 
   * fixed rendering error due to invalid `ColorBlend` position
   * fixed inheriting `text-anchor` and `baseline-shift` attributes
   * prevent crashes on zero length segments or paths
-  * fixed handling of nested SVGs (see [#244](https://github.com/vvvv/SVG/issues/244))
-  * fixed crash in `use` elements with transformation (see [#64](https://github.com/vvvv/SVG/issues/64)) 
-  * fixed overflow handling for view boxes (see [#279](https://github.com/vvvv/SVG/issues/279))
-  * bounds in path based elements did not consider transformations (see [#281](https://github.com/vvvv/SVG/issues/281))
+  * fixed handling of nested SVGs (see [#244](https://github.com/svg-net/SVG/issues/244))
+  * fixed crash in `use` elements with transformation (see [#64](https://github.com/svg-net/SVG/issues/64)) 
+  * fixed overflow handling for view boxes (see [#279](https://github.com/svg-net/SVG/issues/279))
+  * bounds in path based elements did not consider transformations (see [#281](https://github.com/svg-net/SVG/issues/281))


### PR DESCRIPTION
- both repository and GH pages URLs are affected

This changes all occurences of `github.com/vvvv/SVG` and `vvvv.github.io/SVG` to the new URLs.
Mentions of vvvv related to copyright remain.

@tebjan - please check if this is sufficient.