### PR TITLE
Correct Svg.Benchmark namespaces and cleanup csproj

### DIFF
--- a/Tests/Svg.Benchmark/CoordinateParserBenchmarks.cs
+++ b/Tests/Svg.Benchmark/CoordinateParserBenchmarks.cs
@@ -3,9 +3,9 @@ using System.Text;
 using BenchmarkDotNet.Attributes;
 using Svg;
 
-namespace Svg.Benchmarks
+namespace Svg.Benchmark
 {
-    public class CoordinateParserBenchmarks
+    public class CoordinateParserBenchmark
     {
         [Benchmark]
         public void CoordinateParser_TryGetBool()

--- a/Tests/Svg.Benchmark/Program.cs
+++ b/Tests/Svg.Benchmark/Program.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Validators;
 using BenchmarkDotNet.Environments;
 
-namespace Svg.Benchmarks
+namespace Svg.Benchmark
 {
     class Program
     {

--- a/Tests/Svg.Benchmark/Svg.Benchmark.csproj
+++ b/Tests/Svg.Benchmark/Svg.Benchmark.csproj
@@ -7,9 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="../W3CTestSuite/svg/__AJ_Digital_Camera.svg" />
-    <EmbeddedResource Include="../W3CTestSuite/svg/__issue-134-01.svg" />
-    <EmbeddedResource Include="../W3CTestSuite/svg/__tiger.svg" />
+    <EmbeddedResource Include="..\W3CTestSuite\svg\__AJ_Digital_Camera.svg">
+      <Link>Assets\__AJ_Digital_Camera.svg</Link>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\W3CTestSuite\svg\__issue-134-01.svg">
+      <Link>Assets\__issue-134-01.svg</Link>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\W3CTestSuite\svg\__tiger.svg">
+      <Link>Assets\__tiger.svg</Link>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>
@@ -23,6 +29,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)'=='net461'">
     <Reference Include="WindowsBase" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="BenchmarkDotNet.Artifacts\**" />
   </ItemGroup>
 
 </Project>

--- a/Tests/Svg.Benchmark/SvgDocumentBenchmarks.cs
+++ b/Tests/Svg.Benchmark/SvgDocumentBenchmarks.cs
@@ -2,11 +2,11 @@ using BenchmarkDotNet.Attributes;
 using System.IO;
 using Svg;
 
-namespace Svg.Benchmarks
+namespace Svg.Benchmark
 {
     public class SvgDocumentBenchmarks
     {
-        private Stream Open(string name) => typeof(Program).Assembly.GetManifestResourceStream($"Svg.Benchmark.{name}");
+        private Stream Open(string name) => typeof(Program).Assembly.GetManifestResourceStream($"Svg.Benchmark.Assets.{name}");
 
         [Benchmark]
         public void SvgDocument_Open_AJ_Digital_Camera()

--- a/Tests/Svg.Benchmark/SvgPathBuilderBenchmarks.cs
+++ b/Tests/Svg.Benchmark/SvgPathBuilderBenchmarks.cs
@@ -1,7 +1,7 @@
 using BenchmarkDotNet.Attributes;
 using Svg;
 
-namespace Svg.Benchmarks
+namespace Svg.Benchmark
 {
     public class SvgPathBuilderBenchmarks
     {

--- a/Tests/Svg.Benchmark/SvgTransformConverterBenchmarks.cs
+++ b/Tests/Svg.Benchmark/SvgTransformConverterBenchmarks.cs
@@ -3,7 +3,7 @@ using BenchmarkDotNet.Attributes;
 using Svg;
 using Svg.Transforms;
 
-namespace Svg.Benchmarks
+namespace Svg.Benchmark
 {
     public class SvgTransformConverterBenchmarks
     {

--- a/Tests/Svg.Benchmark/ToStringBenchmarks.cs
+++ b/Tests/Svg.Benchmark/ToStringBenchmarks.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using BenchmarkDotNet.Attributes;
 
-namespace Svg.Benchmarks
+namespace Svg.Benchmark
 {
     public class ToStringBenchmarks
     {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Split from #786

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->
Correct Svg.Benchmark namespaces and cleanup csproj

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
