### PR TITLE
Performance optimizations for SvgNumberCollectionConverter parser

### DIFF
--- a/Tests/Svg.Benchmark/README.md
+++ b/Tests/Svg.Benchmark/README.md
@@ -35,3 +35,9 @@ dotnet run -c Release -f netcoreapp3.1 -- -f '*CoordinateParser_*'
 ```
 dotnet run -c Release -f netcoreapp3.1 -- -f '*SvgTransformConverter_*'
 ```
+
+### Run `SvgNumberCollectionConverter` Benchmarks
+
+```
+dotnet run -c Release -f netcoreapp3.1 -- -f '*SvgNumberCollectionConverter_*'
+```

--- a/Tests/Svg.Benchmark/SvgNumberCollectionConverterBenchmarks.cs
+++ b/Tests/Svg.Benchmark/SvgNumberCollectionConverterBenchmarks.cs
@@ -1,0 +1,15 @@
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace Svg.Benchmark
+{
+    public class SvgNumberCollectionConverterBenchmarks
+    {
+        [Benchmark]
+        public void SvgNumberCollectionConverter_Parse()
+        {
+            SvgNumberCollectionConverter.Parse("1.6 3.2 1.2 5".AsSpan());
+            SvgNumberCollectionConverter.Parse("1.6,3.2,1.2,5".AsSpan());
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Split from #786

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

Performance optimizations for SvgNumberCollectionConverter parser

```bash
dotnet run -c Release -f netcoreapp3.1 -- -f '*SvgNumberCollectionConverter_*'
```

* master

|                             Method |     Mean |     Error |    StdDev |      Op/s | Rank |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------------- |---------:|----------:|----------:|----------:|-----:|-------:|------:|------:|----------:|
| SvgNumberCollectionConverter_Parse | 1.256 us | 0.0198 us | 0.0176 us | 795,915.9 |    1 | 0.0305 |     - |     - |     576 B |

* PR

|                             Method |     Mean |     Error |    StdDev |      Op/s | Rank |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------------- |---------:|----------:|----------:|----------:|-----:|-------:|------:|------:|----------:|
| SvgNumberCollectionConverter_Parse | 1.091 us | 0.0135 us | 0.0119 us | 916,318.2 |    1 | 0.0076 |     - |     - |     144 B |


#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
