### PR TITLE
Refactor SvgTransformConverter to have Parse method and use StringParser

### DIFF
--- a/Source/Transforms/SvgTransformConverter.cs
+++ b/Source/Transforms/SvgTransformConverter.cs
@@ -63,34 +63,10 @@ namespace Svg.Transforms
             return TransformType.Invalid;
         }
 
-        private static float ToFloat(ref ReadOnlySpan<char> value)
+        public static SvgTransformCollection Parse(ReadOnlySpan<char> transform)
         {
-#if NETSTANDARD2_1 || NETCORE || NETCOREAPP2_1 || NETCOREAPP3_1 || NET5_0
-            return float.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
-#else
-            return float.Parse(value.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture);
-#endif
-        }
-
-        /// <summary>
-        /// Converts the given object to the type of this converter, using the specified context and culture information.
-        /// </summary>
-        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext"/> that provides a format context.</param>
-        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo"/> to use as the current culture.</param>
-        /// <param name="value">The <see cref="T:System.Object"/> to convert.</param>
-        /// <returns>
-        /// An <see cref="T:System.Object"/> that represents the converted value.
-        /// </returns>
-        /// <exception cref="T:System.NotSupportedException">The conversion cannot be performed. </exception>
-        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
-        {
-            if (value is not string str)
-            {
-                return base.ConvertFrom(context, culture, value);
-            }
-
             var transformList = new SvgTransformCollection();
-            var source = str.AsSpan().TrimStart();
+            var source = transform.TrimStart();
             var sourceLength = source.Length;
             var splitChars = SplitChars.AsSpan();
 
@@ -113,215 +89,223 @@ namespace Svg.Transforms
                 switch (transformType)
                 {
                     case TransformType.Translate:
+                    {
+                        var count = 0;
+                        var x = default(float);
+                        var y = default(float);
+
+                        foreach (var part in parts)
                         {
-                            var count = 0;
-                            var x = default(float);
-                            var y = default(float);
-
-                            foreach (var part in parts)
+                            var partValue = part.Value;
+                            if (count == 0)
                             {
-                                var partValue = part.Value;
-                                if (count == 0)
-                                {
-                                    x = ToFloat(ref partValue);
-                                }
-                                else if (count == 1)
-                                {
-                                    y = ToFloat(ref partValue);
-                                }
-                                count++;
+                                x = StringParser.ToFloat(ref partValue);
+                            }
+                            else if (count == 1)
+                            {
+                                y = StringParser.ToFloat(ref partValue);
                             }
 
-                            if (count == 0 || count > 2)
-                            {
-                                throw new FormatException("Translate transforms must be in the format 'translate(x [y])'");
-                            }
-
-                            transformList.Add(count > 1 ? new SvgTranslate(x, y) : new SvgTranslate(x));
+                            count++;
                         }
+
+                        if (count == 0 || count > 2)
+                        {
+                            throw new FormatException("Translate transforms must be in the format 'translate(x [y])'");
+                        }
+
+                        transformList.Add(count > 1 ? new SvgTranslate(x, y) : new SvgTranslate(x));
+                    }
                         break;
                     case TransformType.Rotate:
+                    {
+                        int count = 0;
+                        var angle = default(float);
+                        var cx = default(float);
+                        var cy = default(float);
+
+                        foreach (var part in parts)
                         {
-                            int count = 0;
-                            var angle = default(float);
-                            var cx = default(float);
-                            var cy = default(float);
-
-                            foreach (var part in parts)
+                            var partValue = part.Value;
+                            if (count == 0)
                             {
-                                var partValue = part.Value;
-                                if (count == 0)
-                                {
-                                    angle = ToFloat(ref partValue);
-                                }
-                                else if (count == 1)
-                                {
-                                    cx = ToFloat(ref partValue);
-                                }
-                                else if (count == 2)
-                                {
-                                    cy = ToFloat(ref partValue);
-                                }
-                                count++;
+                                angle = StringParser.ToFloat(ref partValue);
+                            }
+                            else if (count == 1)
+                            {
+                                cx = StringParser.ToFloat(ref partValue);
+                            }
+                            else if (count == 2)
+                            {
+                                cy = StringParser.ToFloat(ref partValue);
                             }
 
-                            if (count != 1 && count != 3)
-                            {
-                                throw new FormatException("Rotate transforms must be in the format 'rotate(angle [cx cy])'");
-                            }
-
-                            transformList.Add(count == 1 ? new SvgRotate(angle) : new SvgRotate(angle, cx, cy));
+                            count++;
                         }
+
+                        if (count != 1 && count != 3)
+                        {
+                            throw new FormatException("Rotate transforms must be in the format 'rotate(angle [cx cy])'");
+                        }
+
+                        transformList.Add(count == 1 ? new SvgRotate(angle) : new SvgRotate(angle, cx, cy));
+                    }
                         break;
                     case TransformType.Scale:
+                    {
+                        int count = 0;
+                        var sx = default(float);
+                        var sy = default(float);
+
+                        foreach (var part in parts)
                         {
-                            int count = 0;
-                            var sx = default(float);
-                            var sy = default(float);
-
-                            foreach (var part in parts)
+                            var partValue = part.Value;
+                            if (count == 0)
                             {
-                                var partValue = part.Value;
-                                if (count == 0)
-                                {
-                                    sx = ToFloat(ref partValue);
-                                }
-                                else if (count == 1)
-                                {
-                                    sy = ToFloat(ref partValue);
-                                }
-                                count++;
+                                sx = StringParser.ToFloat(ref partValue);
+                            }
+                            else if (count == 1)
+                            {
+                                sy = StringParser.ToFloat(ref partValue);
                             }
 
-                            if (count == 0 || count > 2)
-                            {
-                                throw new FormatException("Scale transforms must be in the format 'scale(x [y])'");
-                            }
-
-                            transformList.Add(count > 1 ? new SvgScale(sx, sy) : new SvgScale(sx));
+                            count++;
                         }
+
+                        if (count == 0 || count > 2)
+                        {
+                            throw new FormatException("Scale transforms must be in the format 'scale(x [y])'");
+                        }
+
+                        transformList.Add(count > 1 ? new SvgScale(sx, sy) : new SvgScale(sx));
+                    }
                         break;
                     case TransformType.Matrix:
+                    {
+                        int count = 0;
+                        var m11 = default(float);
+                        var m12 = default(float);
+                        var m21 = default(float);
+                        var m22 = default(float);
+                        var dx = default(float);
+                        var dy = default(float);
+
+                        foreach (var part in parts)
                         {
-                            int count = 0;
-                            var m11 = default(float);
-                            var m12 = default(float);
-                            var m21 = default(float);
-                            var m22 = default(float);
-                            var dx = default(float);
-                            var dy = default(float);
-
-                            foreach (var part in parts)
+                            var partValue = part.Value;
+                            if (count == 0)
                             {
-                                var partValue = part.Value;
-                                if (count == 0)
-                                {
-                                    m11 = ToFloat(ref partValue);
-                                }
-                                else if (count == 1)
-                                {
-                                    m12 = ToFloat(ref partValue);
-                                }
-                                else if (count == 2)
-                                {
-                                    m21 = ToFloat(ref partValue);
-                                }
-                                else if (count == 3)
-                                {
-                                    m22 = ToFloat(ref partValue);
-                                }
-                                else if (count == 4)
-                                {
-                                    dx = ToFloat(ref partValue);
-                                }
-                                else if (count == 5)
-                                {
-                                    dy = ToFloat(ref partValue);
-                                }
-                                count++;
+                                m11 = StringParser.ToFloat(ref partValue);
+                            }
+                            else if (count == 1)
+                            {
+                                m12 = StringParser.ToFloat(ref partValue);
+                            }
+                            else if (count == 2)
+                            {
+                                m21 = StringParser.ToFloat(ref partValue);
+                            }
+                            else if (count == 3)
+                            {
+                                m22 = StringParser.ToFloat(ref partValue);
+                            }
+                            else if (count == 4)
+                            {
+                                dx = StringParser.ToFloat(ref partValue);
+                            }
+                            else if (count == 5)
+                            {
+                                dy = StringParser.ToFloat(ref partValue);
                             }
 
-                            if (count != 6)
-                            {
-                                throw new FormatException("Matrix transforms must be in the format 'matrix(m11 m12 m21 m22 dx dy)'");
-                            }
-
-                            transformList.Add(new SvgMatrix(new List<float>(6) { m11, m12, m21, m22, dx, dy }));
+                            count++;
                         }
+
+                        if (count != 6)
+                        {
+                            throw new FormatException(
+                                "Matrix transforms must be in the format 'matrix(m11 m12 m21 m22 dx dy)'");
+                        }
+
+                        transformList.Add(new SvgMatrix(new List<float>(6) {m11, m12, m21, m22, dx, dy}));
+                    }
                         break;
                     case TransformType.Shear:
+                    {
+                        int count = 0;
+                        var hx = default(float);
+                        var hy = default(float);
+
+                        foreach (var part in parts)
                         {
-                            int count = 0;
-                            var hx = default(float);
-                            var hy = default(float);
-
-                            foreach (var part in parts)
+                            var partValue = part.Value;
+                            if (count == 0)
                             {
-                                var partValue = part.Value;
-                                if (count == 0)
-                                {
-                                    hx = ToFloat(ref partValue);
-                                }
-                                else if (count == 1)
-                                {
-                                    hy = ToFloat(ref partValue);
-                                }
-                                count++;
+                                hx = StringParser.ToFloat(ref partValue);
+                            }
+                            else if (count == 1)
+                            {
+                                hy = StringParser.ToFloat(ref partValue);
                             }
 
-                            if (count == 0 || count > 2)
-                            {
-                                throw new FormatException("Shear transforms must be in the format 'shear(x [y])'");
-                            }
-
-                            transformList.Add(count > 1 ? new SvgShear(hx, hy) : new SvgShear(hx));
+                            count++;
                         }
+
+                        if (count == 0 || count > 2)
+                        {
+                            throw new FormatException("Shear transforms must be in the format 'shear(x [y])'");
+                        }
+
+                        transformList.Add(count > 1 ? new SvgShear(hx, hy) : new SvgShear(hx));
+                    }
                         break;
                     case TransformType.SkewX:
+                    {
+                        int count = 0;
+                        var ax = default(float);
+
+                        foreach (var part in parts)
                         {
-                            int count = 0;
-                            var ax = default(float);
-
-                            foreach (var part in parts)
+                            var partValue = part.Value;
+                            if (count == 0)
                             {
-                                var partValue = part.Value;
-                                if (count == 0)
-                                {
-                                    ax = ToFloat(ref partValue);
-                                }
-                                count++;
+                                ax = StringParser.ToFloat(ref partValue);
                             }
 
-                            if (count != 1)
-                            {
-                                throw new FormatException("SkewX transforms must be in the format 'skewX(a)'");
-                            }
-
-                            transformList.Add(new SvgSkew(ax, 0f));
+                            count++;
                         }
+
+                        if (count != 1)
+                        {
+                            throw new FormatException("SkewX transforms must be in the format 'skewX(a)'");
+                        }
+
+                        transformList.Add(new SvgSkew(ax, 0f));
+                    }
                         break;
                     case TransformType.SkewY:
+                    {
+                        int count = 0;
+                        var ay = default(float);
+
+                        foreach (var part in parts)
                         {
-                            int count = 0;
-                            var ay = default(float);
-
-                            foreach (var part in parts)
+                            var partValue = part.Value;
+                            if (count == 0)
                             {
-                                var partValue = part.Value;
-                                if (count == 0)
-                                {
-                                    ay = ToFloat(ref partValue);
-                                }
-                                count++;
+                                ay = StringParser.ToFloat(ref partValue);
                             }
 
-                            if (count != 1)
-                            {
-                                throw new FormatException("SkewY transforms must be in the format 'skewY(a)'");
-                            }
-
-                            transformList.Add(new SvgSkew(0f, ay));
+                            count++;
                         }
+
+                        if (count != 1)
+                        {
+                            throw new FormatException("SkewY transforms must be in the format 'skewY(a)'");
+                        }
+
+                        transformList.Add(new SvgSkew(0f, ay));
+                    }
                         break;
                 }
 
@@ -340,7 +324,26 @@ namespace Svg.Transforms
             }
 
             return transformList;
+        }
 
+        /// <summary>
+        /// Converts the given object to the type of this converter, using the specified context and culture information.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext"/> that provides a format context.</param>
+        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo"/> to use as the current culture.</param>
+        /// <param name="value">The <see cref="T:System.Object"/> to convert.</param>
+        /// <returns>
+        /// An <see cref="T:System.Object"/> that represents the converted value.
+        /// </returns>
+        /// <exception cref="T:System.NotSupportedException">The conversion cannot be performed. </exception>
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is not string transform)
+            {
+                return base.ConvertFrom(context, culture, value);
+            }
+
+            return Parse(transform.AsSpan());
         }
 
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)

--- a/Tests/Svg.Benchmark/SvgTransformConverterBenchmarks.cs
+++ b/Tests/Svg.Benchmark/SvgTransformConverterBenchmarks.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using BenchmarkDotNet.Attributes;
 using Svg;
@@ -7,48 +8,46 @@ namespace Svg.Benchmark
 {
     public class SvgTransformConverterBenchmarks
     {
-        private static SvgTransformConverter _converter = new SvgTransformConverter();
-
         [Benchmark]
-        public void SvgTransformConverter_ConvertFrom_Matrix_1()
+        public void SvgTransformConverter_Parse_Matrix_1()
         {
-            _converter.ConvertFrom(null, CultureInfo.InvariantCulture, "matrix(252,0,0,252,7560,11340)");
+            SvgTransformConverter.Parse("matrix(252,0,0,252,7560,11340)".AsSpan());
         }
 
         [Benchmark]
-        public void SvgTransformConverter_ConvertFrom_Matrix_2()
+        public void SvgTransformConverter_Parse_Matrix_2()
         {
-            _converter.ConvertFrom(null, CultureInfo.InvariantCulture, "matrix(-4.37114e-08,1,-1,-4.37114e-08,181,409.496)");
+            SvgTransformConverter.Parse("matrix(-4.37114e-08,1,-1,-4.37114e-08,181,409.496)".AsSpan());
         }
 
         [Benchmark]
-        public void SvgTransformConverter_ConvertFrom_Matrix_3()
+        public void SvgTransformConverter_Parse_Matrix_3()
         {
-            _converter.ConvertFrom(null, CultureInfo.InvariantCulture, "matrix(0.74811711,0.48689734,-0.42145482,0.93331568,324.55155,94.282562)");
+            SvgTransformConverter.Parse("matrix(0.74811711,0.48689734,-0.42145482,0.93331568,324.55155,94.282562)".AsSpan());
         }
 
         [Benchmark]
-        public void SvgTransformConverter_ConvertFrom_Matrix_4()
+        public void SvgTransformConverter_Parse_Matrix_4()
         {
-            _converter.ConvertFrom(null, CultureInfo.InvariantCulture, "matrix(0.879978,0.475015,-0.475015,0.879978,120.2732,-136.2899)");
+            SvgTransformConverter.Parse("matrix(0.879978,0.475015,-0.475015,0.879978,120.2732,-136.2899)".AsSpan());
         }
 
         [Benchmark]
-        public void SvgTransformConverter_ConvertFrom_Rotate_Translate()
+        public void SvgTransformConverter_Parse_Rotate_Translate()
         {
-            _converter.ConvertFrom(null, CultureInfo.InvariantCulture, "rotate(180), translate(-50, 0)");
+            SvgTransformConverter.Parse("rotate(180), translate(-50, 0)".AsSpan());
         }
 
         [Benchmark]
-        public void SvgTransformConverter_ConvertFrom_Translate_Rotate()
+        public void SvgTransformConverter_Parse_Translate_Rotate()
         {
-            _converter.ConvertFrom(null, CultureInfo.InvariantCulture, "translate(9, 241) rotate(-90)");
+            SvgTransformConverter.Parse("translate(9, 241) rotate(-90)".AsSpan());
         }
 
         [Benchmark]
-        public void SvgTransformConverter_ConvertFrom_Matrix_Rotate_Scale()
+        public void SvgTransformConverter_Parse_Matrix_Rotate_Scale()
         {
-            _converter.ConvertFrom(null, CultureInfo.InvariantCulture, "rotate(180 2.5 2.5) scale(0.7142857142857143,0.7142857142857143)");
+            SvgTransformConverter.Parse("rotate(180 2.5 2.5) scale(0.7142857142857143,0.7142857142857143)".AsSpan());
         }
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Split from #786

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

Refactor SvgTransformConverter to have Parse method and use common StringParser

We want to have all converters the same Parse method signature for string conversion to unify API and this can be in feature used to optimize property setter to avoid type converters.

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
