### PR TITLE
Follow MS guidelines for custom exception types.

### DIFF
--- a/Source/Exceptions/SvgException.cs
+++ b/Source/Exceptions/SvgException.cs
@@ -1,38 +1,49 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Runtime.Serialization;
 
 namespace Svg
 {
+    [Serializable]
     public class SvgException : FormatException
     {
-        public SvgException(string message) : base(message)
-        {
-        }
+        public SvgException() { }
+        public SvgException(string message) : base(message) { }
+        public SvgException(string message, Exception inner) : base(message, inner) { }
+
+        protected SvgException(SerializationInfo info, StreamingContext context)
+            : base (info, context) { }
     }
 
+    [Serializable]
     public class SvgIDException : FormatException
     {
-        public SvgIDException(string message)
-            : base(message)
-        {
-        }
+        public SvgIDException() { }
+        public SvgIDException(string message) : base(message) { }
+        public SvgIDException(string message, Exception inner) : base(message, inner) { }
+
+        protected SvgIDException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
     }
 
+    [Serializable]
     public class SvgIDExistsException : SvgIDException
     {
-        public SvgIDExistsException(string message)
-            : base(message)
-        {
-        }
+        public SvgIDExistsException() { }
+        public SvgIDExistsException(string message) : base(message) { }
+        public SvgIDExistsException(string message, Exception inner) : base(message, inner) { }
+
+        protected SvgIDExistsException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
     }
 
+    [Serializable]
     public class SvgIDWrongFormatException : SvgIDException
     {
-        public SvgIDWrongFormatException(string message)
-            : base(message)
-        {
-        }
+        public SvgIDWrongFormatException() { }
+        public SvgIDWrongFormatException(string message) : base(message) { }
+        public SvgIDWrongFormatException(string message, Exception inner) : base(message, inner) { }
+
+        protected SvgIDWrongFormatException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
     }
 }

--- a/Source/Exceptions/SvgGdiPlusCannotBeLoadedException.cs
+++ b/Source/Exceptions/SvgGdiPlusCannotBeLoadedException.cs
@@ -1,8 +1,19 @@
-using System;
+﻿using System;
+using System.Runtime.Serialization;
+
 namespace Svg
 {
+    [Serializable]
     public class SvgGdiPlusCannotBeLoadedException : Exception
     {
-        public SvgGdiPlusCannotBeLoadedException(Exception inner) : base("Cannot initialize gdi+ libraries. This is likely to be caused by running on a non-Windows OS without proper gdi+ replacement. Please refer to the documentation for more details.", inner) {}
+        const string gdiErrorMsg = "Cannot initialize gdi+ libraries. This is likely to be caused by running on a non-Windows OS without proper gdi+ replacement. Please refer to the documentation for more details.";
+
+        public SvgGdiPlusCannotBeLoadedException() : base(gdiErrorMsg) { }
+        public SvgGdiPlusCannotBeLoadedException(string message) : base(message) { }
+        public SvgGdiPlusCannotBeLoadedException(Exception inner) : base(gdiErrorMsg, inner) {}
+        public SvgGdiPlusCannotBeLoadedException(string message, Exception inner) : base(message, inner) { }
+
+        protected SvgGdiPlusCannotBeLoadedException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
     }
 }

--- a/Source/Exceptions/SvgMemoryException.cs
+++ b/Source/Exceptions/SvgMemoryException.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
 
 namespace Svg.Exceptions
 {
@@ -13,8 +10,7 @@ namespace Svg.Exceptions
         public SvgMemoryException(string message) : base(message) { }
         public SvgMemoryException(string message, Exception inner) : base(message, inner) { }
 
-        protected SvgMemoryException(
-            SerializationInfo info,
-            StreamingContext context) : base(info, context) { }
+        protected SvgMemoryException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
     }
 }

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -3,6 +3,9 @@ The release versions are NuGet releases.
 
 ## Unreleased (master)
 
+### Enhancements
+* made exceptions serializable to be able to cross AppDomain boundaries (see [#826](https://github.com/svg-net/SVG/pull/826))
+
 ### Fixes
 * fixed filled polyline not displayed with stroke-width=0 (see [#785](https://github.com/svg-net/SVG/issues/785)
 * fixed unimplemented filter classes issue (see [#768](https://github.com/svg-net/SVG/issues/768)


### PR DESCRIPTION
#### Reference Issue

No existing recorded issue.

#### What does this implement/fix? Explain your changes.

If using this SVG library within a .Net framework AppDomain, exceptions must be serializable to cross AppDomain boundaries.

In addition, implement common exception constructors, in line with guidance at https://docs.microsoft.com/en-us/dotnet/standard/exceptions/best-practices-for-exceptions
