### PR TITLE
Fix: 'Error occurs with empty SVG' issue.

### DIFF
--- a/Samples/SVGViewer/SvgViewer.cs
+++ b/Samples/SVGViewer/SvgViewer.cs
@@ -69,8 +69,7 @@ namespace SVGViewer
 
         private void RenderSvg(SvgDocument svgDoc)
         {
-            if (svgImage.Image != null)
-                svgImage.Image.Dispose();
+            svgImage.Image?.Dispose();
 
             //using (var render = new DebugRenderer())
             //    svgDoc.Draw(render);

--- a/Samples/SVGViewer/SvgViewer.cs
+++ b/Samples/SVGViewer/SvgViewer.cs
@@ -78,7 +78,7 @@ namespace SVGViewer
 
             var baseUri = svgDoc.BaseUri;
             var outputDir = Path.GetDirectoryName(baseUri != null && baseUri.IsFile ? baseUri.LocalPath : Application.ExecutablePath);
-            svgImage.Image.Save(Path.Combine(outputDir, "output.png"));
+            svgImage.Image?.Save(Path.Combine(outputDir, "output.png"));
             svgDoc.Write(Path.Combine(outputDir, "output.svg"));
         }
     }

--- a/Samples/SvgConsole/Program.cs
+++ b/Samples/SvgConsole/Program.cs
@@ -69,7 +69,7 @@ namespace SvgConsole
 
             using (var bitmap = svgDocument.Draw())
             {
-                bitmap.Save(outputPath);
+                bitmap?.Save(outputPath);
             }
         }
 

--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -605,13 +605,16 @@ namespace Svg
         {
             //Trace.TraceInformation("Begin Render");
 
+            var size = Size.Round(GetDimensions());
+            if (size.Width <= 0 || size.Height <= 0)
+                return null;
+
             Bitmap bitmap = null;
             try
             {
                 try
                 {
-                    var size = GetDimensions();
-                    bitmap = new Bitmap((int)Math.Round(size.Width), (int)Math.Round(size.Height));
+                    bitmap = new Bitmap(size.Width, size.Height);
                 }
                 catch (ArgumentException e)
                 {

--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -660,11 +660,12 @@ namespace Svg
         /// <returns>A <see cref="Bitmap"/> containing the rendered document.</returns>
         public virtual Bitmap Draw(int rasterWidth, int rasterHeight)
         {
-            var imageSize = GetDimensions();
-            var bitmapSize = imageSize;
-            this.RasterizeDimensions(ref bitmapSize, rasterWidth, rasterHeight);
+            var svgSize = GetDimensions();
+            var imageSize = svgSize;
+            this.RasterizeDimensions(ref imageSize, rasterWidth, rasterHeight);
 
-            if (bitmapSize.Width == 0 || bitmapSize.Height == 0)
+            var bitmapSize = Size.Round(imageSize);
+            if (bitmapSize.Width <= 0 || bitmapSize.Height <= 0)
                 return null;
 
             Bitmap bitmap = null;
@@ -672,7 +673,7 @@ namespace Svg
             {
                 try
                 {
-                    bitmap = new Bitmap((int)Math.Round(bitmapSize.Width), (int)Math.Round(bitmapSize.Height));
+                    bitmap = new Bitmap(bitmapSize.Width, bitmapSize.Height);
                 }
                 catch (ArgumentException e)
                 {
@@ -682,8 +683,8 @@ namespace Svg
 
                 using (var renderer = SvgRenderer.FromImage(bitmap))
                 {
-                    renderer.ScaleTransform(bitmapSize.Width / imageSize.Width, bitmapSize.Height / imageSize.Height);
-                    var boundable = new GenericBoundable(0, 0, imageSize.Width, imageSize.Height);
+                    renderer.ScaleTransform(imageSize.Width / svgSize.Width, imageSize.Height / svgSize.Height);
+                    var boundable = new GenericBoundable(0, 0, svgSize.Width, svgSize.Height);
                     this.Draw(renderer, boundable);
                 }
             }
@@ -711,8 +712,8 @@ namespace Svg
             // Ratio of height/width of the original SVG size, to be used for scaling transformation
             float ratio = size.Height / size.Width;
 
-            size.Width = rasterWidth > 0 ? (float)rasterWidth : size.Width;
-            size.Height = rasterHeight > 0 ? (float)rasterHeight : size.Height;
+            size.Width = rasterWidth > 0 ? rasterWidth : size.Width;
+            size.Height = rasterHeight > 0 ? rasterHeight : size.Height;
 
             if (rasterHeight == 0 && rasterWidth > 0)
             {

--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -628,8 +628,7 @@ namespace Svg
             }
             catch
             {
-                if (bitmap != null)
-                    bitmap.Dispose();
+                bitmap?.Dispose();
                 throw;
             }
 
@@ -690,8 +689,7 @@ namespace Svg
             }
             catch
             {
-                if (bitmap != null)
-                    bitmap.Dispose();
+                bitmap?.Dispose();
                 throw;
             }
 

--- a/Source/Web/SvgHandler.cs
+++ b/Source/Web/SvgHandler.cs
@@ -1,4 +1,4 @@
-#if NETFULL
+﻿#if NETFULL
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -128,7 +128,7 @@ namespace Svg.Web
                         {
                             using (MemoryStream ms = new MemoryStream())
                             {
-                                bitmap.Save(ms, ImageFormat.Png);
+                                bitmap?.Save(ms, ImageFormat.Png);
                                 this._state._context.Response.ContentType = "image/png";
                                 ms.WriteTo(this._state._context.Response.OutputStream);
                             }

--- a/Tests/Svg.UnitTests/SvgTestHelper.cs
+++ b/Tests/Svg.UnitTests/SvgTestHelper.cs
@@ -246,7 +246,7 @@ namespace Svg.UnitTests
         {
             using (var ms = new MemoryStream())
             {
-                img.Save(ms, ImageFormat.Png);
+                img?.Save(ms, ImageFormat.Png);
                 ms.Flush();
                 Assert.IsTrue(ms.Length >= ExpectedSize, $"Svg file size {ms.Length} does not match expected minimum size (expected {ExpectedSize}).");
             }

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -7,11 +7,12 @@ The release versions are NuGet releases.
 * minimize XmlTextReader customization (see [PR #836](https://github.com/svg-net/SVG/pull/836))
 
 ### Fixes
-* fixed filled polyline not displayed with stroke-width=0 (see [#785](https://github.com/svg-net/SVG/issues/785)
-* fixed unimplemented filter classes issue (see [#768](https://github.com/svg-net/SVG/issues/768)
-* fixed StackOverFlowException (see [#755](https://github.com/svg-net/SVG/issues/755)
-* fixed different prefix is assigned using XmlTextWriter (see [#817](https://github.com/svg-net/SVG/issues/817)
-* fixed scaling if opacity is not 1 (see [#863](https://github.com/svg-net/SVG/issues/863)
+* fixed filled polyline not displayed with stroke-width=0 (see [#785](https://github.com/svg-net/SVG/issues/785))
+* fixed unimplemented filter classes issue (see [#768](https://github.com/svg-net/SVG/issues/768))
+* fixed StackOverFlowException (see [#755](https://github.com/svg-net/SVG/issues/755))
+* fixed different prefix is assigned using XmlTextWriter (see [#817](https://github.com/svg-net/SVG/issues/817))
+* fixed scaling if opacity is not 1 (see [#863](https://github.com/svg-net/SVG/issues/863))
+* fixed error occurs with empty SVG (see [PR #827](https://github.com/svg-net/SVG/pull/827))
 
 ## [Version 3.2.3](https://www.nuget.org/packages/Svg/3.2.3)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Ref. #755

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

Fixes issue that occurred error with empty SVG such as:

```svg
<?xml version="1.0" encoding="utf-8"?>
<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">
</svg>
```

Error
```
{"Cannot process SVG file, cannot allocate the required memory"} | Svg.Exceptions.SvgMemoryException
```

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
