### PR TITLE
Fix: different prefix is assigned using XmlTextWriter.

### DIFF
--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -768,16 +768,15 @@ namespace Svg
             }
         }
 
-        protected override void WriteStartElement(XmlWriter writer)
+        protected override void WriteAttributes(XmlWriter writer)
         {
-            base.WriteStartElement(writer);
-
+            writer.WriteAttributeString("version", "1.1");
             foreach (var ns in SvgAttributeAttribute.Namespaces)
             {
                 writer.WriteAttributeString("xmlns", ns.Key, null, ns.Value);
             }
 
-            writer.WriteAttributeString("version", "1.1");
+            base.WriteAttributes(writer);
         }
     }
 }

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -10,6 +10,7 @@ The release versions are NuGet releases.
 * fixed filled polyline not displayed with stroke-width=0 (see [#785](https://github.com/svg-net/SVG/issues/785)
 * fixed unimplemented filter classes issue (see [#768](https://github.com/svg-net/SVG/issues/768)
 * fixed StackOverFlowException (see [#755](https://github.com/svg-net/SVG/issues/755)
+* fixed different prefix is assigned using XmlTextWriter (see [#817](https://github.com/svg-net/SVG/issues/817)
 
 ## [Version 3.2.3](https://www.nuget.org/packages/Svg/3.2.3)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Fixes a part of #817

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

- Degraded from #760.
- For `XmlWriter`, fixed by #824.

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
