### PR TITLE
Fix: #863 'SVG image is blurred when some sections have opacity<>1' issue.

### DIFF
--- a/Source/Basic Shapes/SvgVisualElement.cs
+++ b/Source/Basic Shapes/SvgVisualElement.cs
@@ -156,7 +156,7 @@ namespace Svg
                         using (var transform = renderer.Transform)
                         {
                             scaleX = Math.Max(scaleX, Math.Abs(transform.Elements[0]));
-                            scaleY = Math.Max(scaleX, Math.Abs(transform.Elements[3]));
+                            scaleY = Math.Max(scaleY, Math.Abs(transform.Elements[3]));
                         }
 
                         using (var canvas = new Bitmap((int)Math.Ceiling(bounds.Width * scaleX), (int)Math.Ceiling(bounds.Height * scaleY)))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Fixes #863

Ref. #864 

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

I fix mistake in PR #864.

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
