### PR TITLE
Enable building code without System.Drawing.Common dependency

### DIFF
--- a/Source/Basic Shapes/SvgCircle.cs
+++ b/Source/Basic Shapes/SvgCircle.cs
@@ -1,4 +1,6 @@
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg
 {
@@ -11,9 +13,9 @@ namespace Svg
         private SvgUnit _centerX = 0f;
         private SvgUnit _centerY = 0f;
         private SvgUnit _radius = 0f;
-
+#if !NO_SDC
         private GraphicsPath _path;
-
+#endif
         /// <summary>
         /// Gets the center point of the circle.
         /// </summary>
@@ -43,6 +45,7 @@ namespace Svg
             get { return _radius; }
             set { _radius = value; Attributes["r"] = value; IsPathDirty = true; }
         }
+#if !NO_SDC
 
         /// <summary>
         /// Gets the <see cref="GraphicsPath"/> representing this element.
@@ -83,6 +86,7 @@ namespace Svg
                 base.Render(renderer);
             }
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Basic Shapes/SvgEllipse.cs
+++ b/Source/Basic Shapes/SvgEllipse.cs
@@ -1,4 +1,6 @@
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg
 {
@@ -13,7 +15,9 @@ namespace Svg
         private SvgUnit _radiusX = 0f;
         private SvgUnit _radiusY = 0f;
 
+#if !NO_SDC
         private GraphicsPath _path;
+#endif
 
         [SvgAttribute("cx")]
         public virtual SvgUnit CenterX
@@ -43,6 +47,7 @@ namespace Svg
             set { _radiusY = value; Attributes["ry"] = value; IsPathDirty = true; }
         }
 
+#if !NO_SDC
         /// <summary>
         /// Gets the <see cref="GraphicsPath"/> for this element.
         /// </summary>
@@ -84,6 +89,7 @@ namespace Svg
                 base.Render(renderer);
             }
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Basic Shapes/SvgLine.cs
+++ b/Source/Basic Shapes/SvgLine.cs
@@ -1,5 +1,7 @@
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg
 {
@@ -14,7 +16,11 @@ namespace Svg
         private SvgUnit _endX = 0f;
         private SvgUnit _endY = 0f;
 
+        #if !NO_SDC
+
         private GraphicsPath _path;
+
+        #endif
 
         [SvgAttribute("x1")]
         public SvgUnit StartX
@@ -84,15 +90,16 @@ namespace Svg
                 // Do nothing
             }
         }
+#if !NO_SDC
 
         public override System.Drawing.Drawing2D.GraphicsPath Path(ISvgRenderer renderer)
         {
             if ((this._path == null || this.IsPathDirty) && base.StrokeWidth > 0)
             {
                 PointF start = new PointF(this.StartX.ToDeviceValue(renderer, UnitRenderingType.Horizontal, this),
-                                          this.StartY.ToDeviceValue(renderer, UnitRenderingType.Vertical, this));
+                    this.StartY.ToDeviceValue(renderer, UnitRenderingType.Vertical, this));
                 PointF end = new PointF(this.EndX.ToDeviceValue(renderer, UnitRenderingType.Horizontal, this),
-                                        this.EndY.ToDeviceValue(renderer, UnitRenderingType.Vertical, this));
+                    this.EndY.ToDeviceValue(renderer, UnitRenderingType.Vertical, this));
 
                 this._path = new GraphicsPath();
 
@@ -114,6 +121,7 @@ namespace Svg
             }
             return this._path;
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Basic Shapes/SvgMarkerElement.cs
+++ b/Source/Basic Shapes/SvgMarkerElement.cs
@@ -37,6 +37,7 @@ namespace Svg
             get { return GetAttribute<Uri>("marker-start", true); }
             set { Attributes["marker-start"] = value; }
         }
+#if !NO_SDC
 
         /// <summary>
         /// Renders the stroke of the element to the specified <see cref="ISvgRenderer"/>.
@@ -101,5 +102,6 @@ namespace Svg
 
             return result;
         }
+#endif
     }
 }

--- a/Source/Basic Shapes/SvgPathBasedElement.cs
+++ b/Source/Basic Shapes/SvgPathBasedElement.cs
@@ -1,5 +1,7 @@
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg
 {
@@ -8,6 +10,7 @@ namespace Svg
     /// </summary>
     public abstract partial class SvgPathBasedElement : SvgVisualElement
     {
+#if !NO_SDC
         public override RectangleF Bounds
         {
             get
@@ -26,5 +29,6 @@ namespace Svg
                 }
             }
         }
+#endif
     }
 }

--- a/Source/Basic Shapes/SvgPolygon.cs
+++ b/Source/Basic Shapes/SvgPolygon.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg
 {
@@ -9,7 +11,9 @@ namespace Svg
     [SvgElement("polygon")]
     public partial class SvgPolygon : SvgMarkerElement
     {
+#if !NO_SDC
         private GraphicsPath _path;
+#endif
 
         /// <summary>
         /// The points that make up the SvgPolygon
@@ -20,6 +24,7 @@ namespace Svg
             get { return GetAttribute<SvgPointCollection>("points", false); }
             set { Attributes["points"] = value; IsPathDirty = true; }
         }
+#if !NO_SDC
 
         public override GraphicsPath Path(ISvgRenderer renderer)
         {
@@ -68,6 +73,7 @@ namespace Svg
             }
             return this._path;
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Basic Shapes/SvgPolyline.cs
+++ b/Source/Basic Shapes/SvgPolyline.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.Diagnostics;
 
 namespace Svg
@@ -11,6 +13,7 @@ namespace Svg
     [SvgElement("polyline")]
     public partial class SvgPolyline : SvgPolygon
     {
+#if !NO_SDC
         private GraphicsPath _Path;
 
         public override GraphicsPath Path(ISvgRenderer renderer)
@@ -24,7 +27,7 @@ namespace Svg
                     for (int i = 0; (i + 1) < Points.Count; i += 2)
                     {
                         PointF endPoint = new PointF(Points[i].ToDeviceValue(renderer, UnitRenderingType.Horizontal, this),
-                                                     Points[i + 1].ToDeviceValue(renderer, UnitRenderingType.Vertical, this));
+                            Points[i + 1].ToDeviceValue(renderer, UnitRenderingType.Vertical, this));
 
                         if (renderer == null)
                         {
@@ -53,6 +56,7 @@ namespace Svg
             }
             return _Path;
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Basic Shapes/SvgRectangle.cs
+++ b/Source/Basic Shapes/SvgRectangle.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg
 {
@@ -17,7 +19,9 @@ namespace Svg
         private SvgUnit _cornerRadiusX = 0f;
         private SvgUnit _cornerRadiusY = 0f;
 
+#if !NO_SDC
         private GraphicsPath _path;
+#endif
 
         /// <summary>
         /// Gets an <see cref="SvgPoint"/> representing the top left point of the rectangle.
@@ -108,6 +112,7 @@ namespace Svg
                     return false;
             }
         }
+#if !NO_SDC
 
         /// <summary>
         /// Gets the <see cref="GraphicsPath"/> for this element.
@@ -223,6 +228,7 @@ namespace Svg
                 base.Render(renderer);
             }
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Basic Shapes/SvgVisualElement.cs
+++ b/Source/Basic Shapes/SvgVisualElement.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.Globalization;
 using System.Linq;
 using Svg.ExtensionMethods;
@@ -15,7 +17,9 @@ namespace Svg
     public abstract partial class SvgVisualElement : SvgElement, ISvgBoundable, ISvgStylable, ISvgClipable
     {
         private bool? _requiresSmoothRendering;
+#if !NO_SDC
         private Region _previousClip;
+
 
         /// <summary>
         /// Gets the <see cref="GraphicsPath"/> for this element.
@@ -43,6 +47,7 @@ namespace Svg
         /// </summary>
         /// <value>The bounds.</value>
         public abstract RectangleF Bounds { get; }
+#endif
 
         /// <summary>
         /// Gets the associated <see cref="SvgClipPath"/> if one has been specified.
@@ -122,6 +127,7 @@ namespace Svg
         }
 
         protected virtual bool Renderable { get { return true; } }
+#if !NO_SDC
 
         /// <summary>
         /// Renders the <see cref="SvgElement"/> and contents to the specified <see cref="Graphics"/> object.
@@ -315,14 +321,14 @@ namespace Svg
                                     strokeWidth = Math.Max(strokeWidth, 1f);
 
                                     /* divide by stroke width - GDI uses stroke width as unit.*/
-                                    var dashPattern = strokeDashArray.Select(u => ((u.ToDeviceValue(renderer, UnitRenderingType.Other, this) <= 0f) ? 1f : 
+                                    var dashPattern = strokeDashArray.Select(u => ((u.ToDeviceValue(renderer, UnitRenderingType.Other, this) <= 0f) ? 1f :
                                         u.ToDeviceValue(renderer, UnitRenderingType.Other, this)) / strokeWidth).ToArray();
                                     var length = dashPattern.Length;
 
                                     if (StrokeLineCap == SvgStrokeLineCap.Round)
                                     {
                                         // to handle round caps, we have to adapt the dash pattern
-                                        // by increasing the dash length by the stroke width - GDI draws the rounded 
+                                        // by increasing the dash length by the stroke width - GDI draws the rounded
                                         // edge inside the dash line, SVG draws it outside the line
                                         var pattern = new float[length];
                                         var offset = 1; // the values are already normalized to dash width
@@ -377,7 +383,7 @@ namespace Svg
 
                                         if (dashOffset != 0f)
                                         {
-                                            pen.DashOffset = ((dashOffset.ToDeviceValue(renderer, UnitRenderingType.Other, this) <= 0f) ? 1f : 
+                                            pen.DashOffset = ((dashOffset.ToDeviceValue(renderer, UnitRenderingType.Other, this) <= 0f) ? 1f :
                                                 dashOffset.ToDeviceValue(renderer, UnitRenderingType.Other, this)) / strokeWidth;
                                         }
                                     }
@@ -446,11 +452,11 @@ namespace Svg
                 {
                     clip = clip.Trim();
                     var offsets = (from o in clip.Substring(5, clip.Length - 6).Split(',')
-                                   select float.Parse(o.Trim(), NumberStyles.Any, CultureInfo.InvariantCulture)).ToList();
+                        select float.Parse(o.Trim(), NumberStyles.Any, CultureInfo.InvariantCulture)).ToList();
                     var bounds = this.Bounds;
                     var clipRect = new RectangleF(bounds.Left + offsets[3], bounds.Top + offsets[0],
-                                                  bounds.Width - (offsets[3] + offsets[1]),
-                                                  bounds.Height - (offsets[2] + offsets[0]));
+                        bounds.Width - (offsets[3] + offsets[1]),
+                        bounds.Height - (offsets[2] + offsets[0]));
                     renderer.SetClip(new Region(clipRect), CombineMode.Intersect);
                 }
             }
@@ -486,5 +492,6 @@ namespace Svg
         {
             this.ResetClip(renderer);
         }
+#endif
     }
 }

--- a/Source/Clipping and Masking/ISvgClipable.cs
+++ b/Source/Clipping and Masking/ISvgClipable.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg
 {
@@ -11,6 +13,7 @@ namespace Svg
     /// </summary>
     public interface ISvgClipable
     {
+#if !NO_SDC
         /// <summary>
         /// Gets or sets the ID of the associated <see cref="SvgClipPath"/> if one has been specified.
         /// </summary>
@@ -29,5 +32,6 @@ namespace Svg
         /// </summary>
         /// <param name="renderer">The <see cref="ISvgRenderer"/> to have its clipping region reset.</param>
         void ResetClip(ISvgRenderer renderer);
+#endif
     }
 }

--- a/Source/Clipping and Masking/SvgClipPath.cs
+++ b/Source/Clipping and Masking/SvgClipPath.cs
@@ -1,5 +1,7 @@
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg
 {
@@ -9,7 +11,9 @@ namespace Svg
     [SvgElement("clipPath")]
     public partial class SvgClipPath : SvgElement
     {
+#if !NO_SDC
         private GraphicsPath _path;
+#endif
 
         /// <summary>
         /// Specifies the coordinate system for the clipping path.
@@ -20,6 +24,7 @@ namespace Svg
             get { return GetAttribute("clipPathUnits", false, SvgCoordinateUnits.UserSpaceOnUse); }
             set { Attributes["clipPathUnits"] = value; }
         }
+#if !NO_SDC
 
         /// <summary>
         /// Gets this <see cref="SvgClipPath"/>'s region to be used as a clipping region.
@@ -83,6 +88,7 @@ namespace Svg
             foreach (var child in element.Children)
                 CombinePaths(path, child, renderer);
         }
+#endif
 
         /// <summary>
         /// Called by the underlying <see cref="SvgElement"/> when an element has been added to the
@@ -107,6 +113,7 @@ namespace Svg
             IsPathDirty = true;
         }
 
+#if !NO_SDC
         /// <summary>
         /// Renders the <see cref="SvgElement"/> and contents to the specified <see cref="ISvgRenderer"/> object.
         /// </summary>
@@ -114,6 +121,7 @@ namespace Svg
         protected override void Render(ISvgRenderer renderer)
         {
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/DataTypes/SvgUnit.cs
+++ b/Source/DataTypes/SvgUnit.cs
@@ -90,6 +90,7 @@ namespace Svg
 
             switch (type)
             {
+#if !NO_SDC
                 case SvgUnitType.Em:
                     using (var fontManager = owner?.OwnerDocument?.FontManager == null ? new SvgFontManager() : null)
                     using (var currFont = GetFont(renderer, owner, fontManager))
@@ -120,6 +121,7 @@ namespace Svg
                         }
                     }
                     break;
+#endif
                 case SvgUnitType.Centimeter:
                     _deviceValue = (float)((value / cmInInch) * ppi);
                     break;
@@ -141,6 +143,7 @@ namespace Svg
                 case SvgUnitType.User:
                     _deviceValue = value;
                     break;
+#if !NO_SDC
                 case SvgUnitType.Percentage:
                     // Can't calculate if there is no style owner
                     var boundable = (renderer == null ? (owner == null ? null : owner.OwnerDocument) : renderer.GetBoundable());
@@ -150,7 +153,7 @@ namespace Svg
                         break;
                     }
 
-                    System.Drawing.SizeF size = boundable.Bounds.Size;
+                    SizeF size = boundable.Bounds.Size;
 
                     switch (renderType)
                     {
@@ -176,6 +179,7 @@ namespace Svg
                             break;
                     }
                     break;
+#endif
                 default:
                     _deviceValue = value;
                     break;
@@ -183,12 +187,14 @@ namespace Svg
 
             return this._deviceValue.HasValue ? this._deviceValue.Value : 0f;
         }
+#if !NO_SDC
 
         private IFontDefn GetFont(ISvgRenderer renderer, SvgElement owner, SvgFontManager fontManager)
         {
             var visual = owner?.Parents.OfType<SvgVisualElement>().FirstOrDefault();
             return visual?.GetFont(renderer, fontManager);
         }
+#endif
 
         /// <summary>
         /// Converts the current unit to a percentage, if applicable.

--- a/Source/DataTypes/SvgViewBox.cs
+++ b/Source/DataTypes/SvgViewBox.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.Globalization;
 
 namespace Svg
@@ -107,6 +109,7 @@ namespace Svg
         }
         #endregion
 
+#if !NO_SDC
         public void AddViewBoxTransform(SvgAspectRatio aspectRatio, ISvgRenderer renderer, SvgFragment frag)
         {
             var x = frag == null ? 0f : frag.X.ToDeviceValue(renderer, UnitRenderingType.Horizontal, frag);
@@ -122,7 +125,7 @@ namespace Svg
             var height = frag == null ? Height : frag.Height.ToDeviceValue(renderer, UnitRenderingType.Vertical, frag);
 
             var fScaleX = width / Width;
-            var fScaleY = height / Height; //(MinY < 0 ? -1 : 1) * 
+            var fScaleY = height / Height; //(MinY < 0 ? -1 : 1) *
             var fMinX = -MinX * fScaleX;
             var fMinY = -MinY * fScaleY;
 
@@ -187,6 +190,7 @@ namespace Svg
             renderer.TranslateTransform(fMinX, fMinY, MatrixOrder.Prepend);
             renderer.ScaleTransform(fScaleX, fScaleY, MatrixOrder.Prepend);
         }
+#endif
     }
 
     internal class SvgViewBoxConverter : TypeConverter

--- a/Source/Document Structure/SvgDefinitionList.cs
+++ b/Source/Document Structure/SvgDefinitionList.cs
@@ -6,6 +6,7 @@ namespace Svg
     [SvgElement("defs")]
     public partial class SvgDefinitionList : SvgElement
     {
+#if !NO_SDC
         /// <summary>
         /// Renders the <see cref="SvgElement"/> and contents to the specified <see cref="ISvgRenderer"/> object.
         /// </summary>
@@ -14,6 +15,7 @@ namespace Svg
         {
             // Do nothing. Children should NOT be rendered.
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Document Structure/SvgFragment.cs
+++ b/Source/Document Structure/SvgFragment.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg
 {
@@ -17,7 +19,7 @@ namespace Svg
         /// Gets the SVG namespace string.
         /// </summary>
         public static readonly Uri Namespace = new Uri(SvgNamespaces.SvgNamespace);
-
+#if !NO_SDC
         PointF ISvgBoundable.Location
         {
             get { return PointF.Empty; }
@@ -38,6 +40,7 @@ namespace Svg
         {
             get { return new RectangleF(((ISvgBoundable)this).Location, ((ISvgBoundable)this).Size); }
         }
+#endif
 
         /// <summary>
         /// Gets or sets the position where the left point of the svg should start.
@@ -145,6 +148,7 @@ namespace Svg
             get { return GetAttribute("space", true, XmlSpaceHandling.Default); }
             set { base.SpaceHandling = value; IsPathDirty = true; }
         }
+#if !NO_SDC
 
         /// <summary>
         /// Applies the required transforms to <see cref="ISvgRenderer"/>.
@@ -173,8 +177,8 @@ namespace Svg
                     {
                         var size = this is SvgDocument ? renderer.GetBoundable().Bounds.Size : GetDimensions(renderer);
                         var clip = new RectangleF(X.ToDeviceValue(renderer, UnitRenderingType.Horizontal, this),
-                                                  Y.ToDeviceValue(renderer, UnitRenderingType.Vertical, this),
-                                                  size.Width, size.Height);
+                            Y.ToDeviceValue(renderer, UnitRenderingType.Vertical, this),
+                            size.Width, size.Height);
                         renderer.SetClip(new Region(clip), CombineMode.Intersect);
                         try
                         {
@@ -292,6 +296,7 @@ namespace Svg
 
             return new SizeF(w, h);
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Document Structure/SvgGroup.cs
+++ b/Source/Document Structure/SvgGroup.cs
@@ -1,5 +1,7 @@
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg
 {
@@ -9,6 +11,7 @@ namespace Svg
     [SvgElement("g")]
     public partial class SvgGroup : SvgMarkerElement
     {
+#if !NO_SDC
         /// <summary>
         /// Gets the <see cref="GraphicsPath"/> for this element.
         /// </summary>
@@ -50,6 +53,7 @@ namespace Svg
                 return TransformedBounds(r);
             }
         }
+#endif
 
         protected override bool Renderable { get { return false; } }
 

--- a/Source/Document Structure/SvgImage.cs
+++ b/Source/Document Structure/SvgImage.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.IO;
 using System.Net;
 using System.Text;
@@ -17,7 +19,9 @@ namespace Svg
     {
         private const string MimeTypeSvg = "image/svg+xml";
 
+#if !NO_SDC
         private GraphicsPath _path;
+#endif
         private bool _gettingBounds;
 
         /// <summary>
@@ -73,6 +77,7 @@ namespace Svg
             get { return GetAttribute<string>("href", false); }
             set { Attributes["href"] = value; }
         }
+#if !NO_SDC
 
         /// <summary>
         /// Gets the bounds of the element.
@@ -91,17 +96,19 @@ namespace Svg
                 }
                 _gettingBounds = true;
                 var bounds = TransformedBounds(new RectangleF(Location.ToDeviceValue(null, this),
-                                               new SizeF(Width.ToDeviceValue(null, UnitRenderingType.Horizontal, this),
-                                                         Height.ToDeviceValue(null, UnitRenderingType.Vertical, this))));
+                    new SizeF(Width.ToDeviceValue(null, UnitRenderingType.Horizontal, this),
+                        Height.ToDeviceValue(null, UnitRenderingType.Vertical, this))));
                 _gettingBounds = false;
                 return bounds;
             }
         }
+#endif
 
         internal ExternalType ResolveExternalImages
         {
             get { return SvgDocument.ResolveExternalImages; }
         }
+#if !NO_SDC
 
         /// <summary>
         /// Gets the <see cref="GraphicsPath"/> for this element.
@@ -146,8 +153,8 @@ namespace Svg
                         srcRect = new RectangleF(new PointF(0f, 0f), svg.GetDimensions(renderer));
 
                     var destClip = new RectangleF(Location.ToDeviceValue(renderer, this),
-                                                  new SizeF(Width.ToDeviceValue(renderer, UnitRenderingType.Horizontal, this),
-                                                            Height.ToDeviceValue(renderer, UnitRenderingType.Vertical, this)));
+                        new SizeF(Width.ToDeviceValue(renderer, UnitRenderingType.Horizontal, this),
+                            Height.ToDeviceValue(renderer, UnitRenderingType.Vertical, this)));
                     var destRect = destClip;
                     renderer.SetClip(new Region(destClip), CombineMode.Intersect);
                     SetClip(renderer);
@@ -206,7 +213,7 @@ namespace Svg
                         }
 
                         destRect = new RectangleF(destClip.X + xOffset, destClip.Y + yOffset,
-                                                  srcRect.Width * fScaleX, srcRect.Height * fScaleY);
+                            srcRect.Width * fScaleX, srcRect.Height * fScaleY);
                     }
 
                     if (bmp != null)
@@ -359,6 +366,7 @@ namespace Svg
             else
                 return null;
         }
+#endif
 
         private SvgDocument LoadSvg(Stream stream, Uri baseUri)
         {

--- a/Source/Document Structure/SvgSwitch.cs
+++ b/Source/Document Structure/SvgSwitch.cs
@@ -1,5 +1,7 @@
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg
 {
@@ -9,6 +11,7 @@ namespace Svg
     [SvgElement("switch")]
     public partial class SvgSwitch : SvgVisualElement
     {
+#if !NO_SDC
         /// <summary>
         /// Gets the <see cref="GraphicsPath"/> for this element.
         /// </summary>
@@ -75,6 +78,7 @@ namespace Svg
                 PopTransforms(renderer);
             }
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Document Structure/SvgSymbol.cs
+++ b/Source/Document Structure/SvgSymbol.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg
 {
@@ -32,6 +34,7 @@ namespace Svg
             set { Attributes["preserveAspectRatio"] = value; }
         }
 
+#if !NO_SDC
         /// <summary>
         /// Gets the <see cref="GraphicsPath"/> for this element.
         /// </summary>
@@ -74,8 +77,9 @@ namespace Svg
                 return TransformedBounds(r);
             }
         }
-
+#endif
         protected override bool Renderable { get { return false; } }
+#if !NO_SDC
 
         /// <summary>
         /// Applies the required transforms to <see cref="ISvgRenderer"/>.
@@ -94,6 +98,7 @@ namespace Svg
         {
             if (_parent is SvgUse) base.Render(renderer);
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Document Structure/SvgUse.cs
+++ b/Source/Document Structure/SvgUse.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg
 {
@@ -92,6 +94,7 @@ namespace Svg
             set { Attributes["height"] = value; }
         }
 
+#if !NO_SDC
         /// <summary>
         /// Applies the required transforms to <see cref="ISvgRenderer"/>.
         /// </summary>
@@ -101,8 +104,8 @@ namespace Svg
             if (!base.PushTransforms(renderer))
                 return false;
             renderer.TranslateTransform(X.ToDeviceValue(renderer, UnitRenderingType.Horizontal, this),
-                                        Y.ToDeviceValue(renderer, UnitRenderingType.Vertical, this),
-                                        MatrixOrder.Prepend);
+                Y.ToDeviceValue(renderer, UnitRenderingType.Vertical, this),
+                MatrixOrder.Prepend);
             return true;
         }
 
@@ -111,6 +114,7 @@ namespace Svg
             SvgVisualElement element = (SvgVisualElement)this.OwnerDocument.IdManager.GetElementById(this.ReferencedElement);
             return (element != null && !this.HasRecursiveReference()) ? element.Path(renderer) : null;
         }
+#endif
 
         /// <summary>
         /// Gets an <see cref="SvgPoint"/> representing the top left point of the rectangle.
@@ -120,6 +124,7 @@ namespace Svg
             get { return new SvgPoint(X, Y); }
         }
 
+#if !NO_SDC
         /// <summary>
         /// Gets the bounds of the element.
         /// </summary>
@@ -142,8 +147,10 @@ namespace Svg
                 return new RectangleF();
             }
         }
+#endif
 
         protected override bool Renderable { get { return false; } }
+#if !NO_SDC
 
         protected override void RenderChildren(ISvgRenderer renderer)
         {
@@ -175,6 +182,7 @@ namespace Svg
                 }
             }
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Extensibility/SvgForeignObject.cs
+++ b/Source/Extensibility/SvgForeignObject.cs
@@ -1,5 +1,7 @@
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg
 {
@@ -9,6 +11,8 @@ namespace Svg
     [SvgElement("foreignObject")]
     public partial class SvgForeignObject : SvgVisualElement
     {
+        #if !NO_SDC
+
         /// <summary>
         /// Gets the <see cref="GraphicsPath"/> for this element.
         /// </summary>
@@ -51,6 +55,7 @@ namespace Svg
                 return TransformedBounds(r);
             }
         }
+#endif
 
         protected override bool Renderable { get { return false; } }
 

--- a/Source/Filter Effects/ImageBuffer.cs
+++ b/Source/Filter Effects/ImageBuffer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !NO_SDC
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
@@ -191,3 +192,4 @@ namespace Svg.FilterEffects
         }
     }
 }
+#endif

--- a/Source/Filter Effects/SvgFilter.cs
+++ b/Source/Filter Effects/SvgFilter.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.Linq;
 using Svg.DataTypes;
 
@@ -76,6 +78,7 @@ namespace Svg.FilterEffects
             set { Attributes["href"] = value; }
         }
 
+#if !NO_SDC
         /// <summary>
         /// Renders the <see cref="SvgElement"/> and contents to the specified <see cref="ISvgRenderer"/> object.
         /// </summary>
@@ -135,6 +138,7 @@ namespace Svg.FilterEffects
                 }
             }
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Filter Effects/SvgFilterPrimitive.cs
+++ b/Source/Filter Effects/SvgFilterPrimitive.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg.FilterEffects
 {
@@ -62,6 +64,8 @@ namespace Svg.FilterEffects
             get { return (SvgFilter)this.Parent; }
         }
 
+#if !NO_SDC
         public abstract void Process(ImageBuffer buffer);
+#endif
     }
 }

--- a/Source/Filter Effects/feBlend/SvgBlend.cs
+++ b/Source/Filter Effects/feBlend/SvgBlend.cs
@@ -17,11 +17,13 @@
             set { Attributes["in2"] = value; }
         }
 
+#if !NO_SDC
         public override void Process(ImageBuffer buffer)
         {
             // TODO: Implement feBlend filter Process().
             buffer[Result] = buffer[Input];
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Filter Effects/feColourMatrix/SvgColourMatrix.cs
+++ b/Source/Filter Effects/feColourMatrix/SvgColourMatrix.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Imaging;
+#endif
 using System.Globalization;
 using System.Linq;
 
@@ -38,6 +40,7 @@ namespace Svg.FilterEffects
             get { return _values; }
             set { _values = value; Attributes["values"] = value; }
         }
+#if !NO_SDC
 
         public override void Process(ImageBuffer buffer)
         {
@@ -54,14 +57,14 @@ namespace Svg.FilterEffects
                     value = (string.IsNullOrEmpty(this.Values) ? 0 : float.Parse(this.Values, NumberStyles.Any, CultureInfo.InvariantCulture));
                     colorMatrixElements = new float[][] {
                         new float[] {(float)(0.213 + Math.Cos(value) * +0.787 + Math.Sin(value) * -0.213),
-                                     (float)(0.715 + Math.Cos(value) * -0.715 + Math.Sin(value) * -0.715),
-                                     (float)(0.072 + Math.Cos(value) * -0.072 + Math.Sin(value) * +0.928), 0, 0},
+                            (float)(0.715 + Math.Cos(value) * -0.715 + Math.Sin(value) * -0.715),
+                            (float)(0.072 + Math.Cos(value) * -0.072 + Math.Sin(value) * +0.928), 0, 0},
                         new float[] {(float)(0.213 + Math.Cos(value) * -0.213 + Math.Sin(value) * +0.143),
-                                     (float)(0.715 + Math.Cos(value) * +0.285 + Math.Sin(value) * +0.140),
-                                     (float)(0.072 + Math.Cos(value) * -0.072 + Math.Sin(value) * -0.283), 0, 0},
+                            (float)(0.715 + Math.Cos(value) * +0.285 + Math.Sin(value) * +0.140),
+                            (float)(0.072 + Math.Cos(value) * -0.072 + Math.Sin(value) * -0.283), 0, 0},
                         new float[] {(float)(0.213 + Math.Cos(value) * -0.213 + Math.Sin(value) * -0.787),
-                                     (float)(0.715 + Math.Cos(value) * -0.715 + Math.Sin(value) * +0.715),
-                                     (float)(0.072 + Math.Cos(value) * +0.928 + Math.Sin(value) * +0.072), 0, 0},
+                            (float)(0.715 + Math.Cos(value) * -0.715 + Math.Sin(value) * +0.715),
+                            (float)(0.072 + Math.Cos(value) * +0.928 + Math.Sin(value) * +0.072), 0, 0},
                         new float[] {0, 0, 0, 1, 0},
                         new float[] {0, 0, 0, 0, 1}
                     };
@@ -106,12 +109,13 @@ namespace Svg.FilterEffects
                 using (var g = Graphics.FromImage(result))
                 {
                     g.DrawImage(inputImage, new Rectangle(0, 0, inputImage.Width, inputImage.Height),
-                                0, 0, inputImage.Width, inputImage.Height, GraphicsUnit.Pixel, imageAttrs);
+                        0, 0, inputImage.Width, inputImage.Height, GraphicsUnit.Pixel, imageAttrs);
                     g.Flush();
                 }
                 buffer[this.Result] = result;
             }
         }
+#endif
 
 
         public override SvgElement DeepCopy()

--- a/Source/Filter Effects/feComponentTransfer/SvgComponentTransfer.cs
+++ b/Source/Filter Effects/feComponentTransfer/SvgComponentTransfer.cs
@@ -3,11 +3,13 @@
     [SvgElement("feComponentTransfer")]
     public partial class SvgComponentTransfer : SvgFilterPrimitive
     {
+#if !NO_SDC
         public override void Process(ImageBuffer buffer)
         {
             // TODO: Implement feComponentTransfer filter Process().
             buffer[Result] = buffer[Input];
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Filter Effects/feComposite/SvgComposite.cs
+++ b/Source/Filter Effects/feComposite/SvgComposite.cs
@@ -45,11 +45,13 @@
             set { Attributes["in2"] = value; }
         }
 
+#if !NO_SDC
         public override void Process(ImageBuffer buffer)
         {
             // TODO: Implement feComposite filter Process().
             buffer[Result] = buffer[Input];
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Filter Effects/feConvolveMatrix/SvgConvolveMatrix.cs
+++ b/Source/Filter Effects/feConvolveMatrix/SvgConvolveMatrix.cs
@@ -66,11 +66,13 @@
             set { Attributes["preserveAlpha"] = value; }
         }
 
+#if !NO_SDC
         public override void Process(ImageBuffer buffer)
         {
             // TODO: Implement feConvolveMatrix filter Process().
             buffer[Result] = buffer[Input];
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Filter Effects/feDiffuseLighting/SvgDiffuseLighting.cs
+++ b/Source/Filter Effects/feDiffuseLighting/SvgDiffuseLighting.cs
@@ -47,11 +47,13 @@ namespace Svg.FilterEffects
             }
         }
 
+#if !NO_SDC
         public override void Process(ImageBuffer buffer)
         {
             // TODO: Implement feDiffuseLighting filter Process().
             buffer[Result] = buffer[Input];
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Filter Effects/feDisplacementMap/SvgDisplacementMap.cs
+++ b/Source/Filter Effects/feDisplacementMap/SvgDisplacementMap.cs
@@ -31,11 +31,13 @@
             set { Attributes["in2"] = value; }
         }
 
+#if !NO_SDC
         public override void Process(ImageBuffer buffer)
         {
             // TODO: Implement feDisplacementMap filter Process().
             buffer[Result] = buffer[Input];
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Filter Effects/feFlood/SvgFlood.cs
+++ b/Source/Filter Effects/feFlood/SvgFlood.cs
@@ -17,11 +17,13 @@
             set { Attributes["flood-opacity"] = FixOpacityValue(value); }
         }
 
+#if !NO_SDC
         public override void Process(ImageBuffer buffer)
         {
             // TODO: Implement feFlood filter Process().
             buffer[Result] = buffer[Input];
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Filter Effects/feGaussianBlur/RawBitmap.cs
+++ b/Source/Filter Effects/feGaussianBlur/RawBitmap.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !NO_SDC
+using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
@@ -67,3 +68,4 @@ namespace Svg.FilterEffects
 
     }
 }
+#endif

--- a/Source/Filter Effects/feGaussianBlur/SvgGaussianBlur.cs
+++ b/Source/Filter Effects/feGaussianBlur/SvgGaussianBlur.cs
@@ -70,6 +70,7 @@ namespace Svg.FilterEffects
             _stdDeviationY = stdDeviationY;
             _isPrecalculated = true;
         }
+#if !NO_SDC
 
         public Bitmap Apply(Image inputImage)
         {
@@ -234,6 +235,7 @@ namespace Svg.FilterEffects
                 }
             }
         }
+#endif
 
         /// <summary>
         /// Gets or sets the radius of the blur (only allows for one value - not the two specified in the SVG Spec)
@@ -245,12 +247,14 @@ namespace Svg.FilterEffects
             set { Attributes["stdDeviation"] = value; }
         }
 
+#if !NO_SDC
         public override void Process(ImageBuffer buffer)
         {
             var inputImage = buffer[this.Input];
             var result = Apply(inputImage);
             buffer[this.Result] = result;
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Filter Effects/feImage/SvgImage.cs
+++ b/Source/Filter Effects/feImage/SvgImage.cs
@@ -17,11 +17,13 @@
             set { Attributes["preserveAspectRatio"] = value; }
         }
 
+#if !NO_SDC
         public override void Process(ImageBuffer buffer)
         {
             // TODO: Implement feImage filter Process().
             buffer[Result] = buffer[Input];
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Filter Effects/feMerge/SvgMerge.cs
+++ b/Source/Filter Effects/feMerge/SvgMerge.cs
@@ -6,6 +6,7 @@ namespace Svg.FilterEffects
     [SvgElement("feMerge")]
     public partial class SvgMerge : SvgFilterPrimitive
     {
+#if !NO_SDC
         public override void Process(ImageBuffer buffer)
         {
             var children = this.Children.OfType<SvgMergeNode>().ToList();
@@ -16,12 +17,13 @@ namespace Svg.FilterEffects
                 foreach (var child in children)
                 {
                     g.DrawImage(buffer[child.Input], new Rectangle(0, 0, inputImage.Width, inputImage.Height),
-                                0, 0, inputImage.Width, inputImage.Height, GraphicsUnit.Pixel);
+                        0, 0, inputImage.Width, inputImage.Height, GraphicsUnit.Pixel);
                 }
                 g.Flush();
             }
             buffer[this.Result] = result;
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Filter Effects/feMorphology/SvgMorphology.cs
+++ b/Source/Filter Effects/feMorphology/SvgMorphology.cs
@@ -17,11 +17,13 @@
             set { Attributes["radius"] = value; }
         }
 
+#if !NO_SDC
         public override void Process(ImageBuffer buffer)
         {
             // TODO: Implement feMorphology filter Process().
             buffer[Result] = buffer[Input];
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Filter Effects/feOffset/SvgOffset.cs
+++ b/Source/Filter Effects/feOffset/SvgOffset.cs
@@ -35,24 +35,26 @@ namespace Svg.FilterEffects
             set { _dy = value; Attributes["dy"] = value; }
         }
 
+#if !NO_SDC
         public override void Process(ImageBuffer buffer)
         {
             var inputImage = buffer[this.Input];
             var result = new Bitmap(inputImage.Width, inputImage.Height);
 
             var pts = new PointF[] { new PointF(this.Dx.ToDeviceValue(null, UnitRenderingType.Horizontal, null),
-                                                this.Dy.ToDeviceValue(null, UnitRenderingType.Vertical, null)) };
+                this.Dy.ToDeviceValue(null, UnitRenderingType.Vertical, null)) };
             buffer.Transform.TransformVectors(pts);
 
             using (var g = Graphics.FromImage(result))
             {
                 g.DrawImage(inputImage, new Rectangle((int)pts[0].X, (int)pts[0].Y,
-                                                      inputImage.Width, inputImage.Height),
-                            0, 0, inputImage.Width, inputImage.Height, GraphicsUnit.Pixel);
+                        inputImage.Width, inputImage.Height),
+                    0, 0, inputImage.Width, inputImage.Height, GraphicsUnit.Pixel);
                 g.Flush();
             }
             buffer[this.Result] = result;
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Filter Effects/feSpecularLighting/SvgSpecularLighting.cs
+++ b/Source/Filter Effects/feSpecularLighting/SvgSpecularLighting.cs
@@ -54,11 +54,13 @@ namespace Svg.FilterEffects
             }
         }
 
+#if !NO_SDC
         public override void Process(ImageBuffer buffer)
         {
             // TODO: Implement feSpecularLighting filter Process().
             buffer[Result] = buffer[Input];
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Filter Effects/feTile/SvgTile.cs
+++ b/Source/Filter Effects/feTile/SvgTile.cs
@@ -3,11 +3,13 @@
     [SvgElement("feTile")]
     public partial class SvgTile : SvgFilterPrimitive
     {
+#if !NO_SDC
         public override void Process(ImageBuffer buffer)
         {
             // TODO: Implement feTile filter Process().
             buffer[Result] = buffer[Input];
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Filter Effects/feTurbulence/SvgTurbulence.cs
+++ b/Source/Filter Effects/feTurbulence/SvgTurbulence.cs
@@ -38,11 +38,13 @@
             set { Attributes["type"] = value; }
         }
 
+#if !NO_SDC
         public override void Process(ImageBuffer buffer)
         {
             // TODO: Implement feTurbulence filter Process().
             buffer[Result] = buffer[Input];
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Metadata/SvgDocumentMetadata.cs
+++ b/Source/Metadata/SvgDocumentMetadata.cs
@@ -16,6 +16,7 @@ namespace Svg
             Content = string.Empty;
         }
 
+#if !NO_SDC
         /// <summary>
         /// Renders the <see cref="SvgElement"/> and contents to the specified <see cref="ISvgRenderer"/> object.
         /// </summary>
@@ -24,6 +25,7 @@ namespace Svg
         {
             // Do nothing. Children should NOT be rendered.
         }
+#endif
 
         protected override void WriteChildren(XmlWriter writer)
         {

--- a/Source/Painting/ISvgBoundable.cs
+++ b/Source/Painting/ISvgBoundable.cs
@@ -4,6 +4,7 @@ namespace Svg
 {
     public interface ISvgBoundable
     {
+#if !NO_SDC
         PointF Location
         {
             get;
@@ -18,5 +19,6 @@ namespace Svg
         {
             get;
         }
+#endif
     }
 }

--- a/Source/Painting/ISvgStylable.cs
+++ b/Source/Painting/ISvgStylable.cs
@@ -1,4 +1,6 @@
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg
 {
@@ -19,6 +21,8 @@ namespace Svg
         float StrokeMiterLimit { get; set; }
         SvgUnitCollection StrokeDashArray { get; set; }
         SvgUnit StrokeDashOffset { get; set; }
+#if !NO_SDC
         GraphicsPath Path(ISvgRenderer renderer);
+#endif
     }
 }

--- a/Source/Painting/SvgColourConverter.cs
+++ b/Source/Painting/SvgColourConverter.cs
@@ -120,6 +120,7 @@ namespace Svg
                     return base.ConvertFrom(context, culture, colour);
                 }
 
+#if !NO_SDC
                 switch (colour.ToLowerInvariant())
                 {
                     case "activeborder": return SystemColors.ActiveBorder;
@@ -150,11 +151,12 @@ namespace Svg
                     case "windowframe": return SystemColors.WindowFrame;
                     case "windowtext": return SystemColors.WindowText;
                 }
+#endif
                 int number;
                 if (Int32.TryParse(colour,NumberStyles.Integer, CultureInfo.InvariantCulture, out number))
                 {
                     // numbers are handled as colors by System.Drawing.ColorConverter - we
-                    // have to prevent this and ignore the color instead (see #342) 
+                    // have to prevent this and ignore the color instead (see #342)
                     return SvgPaintServer.NotSet;
                 }
 
@@ -190,9 +192,11 @@ namespace Svg
         {
             if (destinationType == typeof(string))
             {
+#if !NO_SDC
                 var colorString = ColorTranslator.ToHtml((Color)value).Replace("LightGrey", "LightGray");
                 // color names are expected to be lower case in XML
                 return colorString.StartsWith("#", StringComparison.InvariantCulture) ? colorString : colorString.ToLowerInvariant();
+#endif
             }
 
             return base.ConvertTo(context, culture, value, destinationType);

--- a/Source/Painting/SvgColourServer.cs
+++ b/Source/Painting/SvgColourServer.cs
@@ -22,6 +22,7 @@ namespace Svg
             get { return this._colour; }
             set { this._colour = value; }
         }
+#if !NO_SDC
 
         public override Brush GetBrush(SvgVisualElement styleOwner, ISvgRenderer renderer, float opacity, bool forStroke = false)
         {
@@ -36,6 +37,7 @@ namespace Svg
 
             return new SolidBrush(colour);
         }
+#endif
 
         public override string ToString()
         {

--- a/Source/Painting/SvgDeferredPaintServer.cs
+++ b/Source/Painting/SvgDeferredPaintServer.cs
@@ -82,11 +82,13 @@ namespace Svg
             }
         }
 
+#if !NO_SDC
         public override Brush GetBrush(SvgVisualElement styleOwner, ISvgRenderer renderer, float opacity, bool forStroke = false)
         {
             EnsureServer(styleOwner);
             return _concreteServer?.GetBrush(styleOwner, renderer, opacity, forStroke) ?? _fallbackServer?.GetBrush(styleOwner, renderer, opacity, forStroke) ?? NotSet?.GetBrush(styleOwner, renderer, opacity, forStroke);
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Painting/SvgFallbackPaintServer.cs
+++ b/Source/Painting/SvgFallbackPaintServer.cs
@@ -21,6 +21,7 @@ namespace Svg
             _primary = primary;
         }
 
+#if !NO_SDC
         public override Brush GetBrush(SvgVisualElement styleOwner, ISvgRenderer renderer, float opacity, bool forStroke = false)
         {
             try
@@ -33,6 +34,7 @@ namespace Svg
                 _primary.GetCallback = null;
             }
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Painting/SvgGradientServer.cs
+++ b/Source/Painting/SvgGradientServer.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using Svg.Transforms;
 
 namespace Svg
@@ -110,6 +112,7 @@ namespace Svg
             set { Attributes["stop-opacity"] = FixOpacityValue(value); }
         }
 
+#if !NO_SDC
         protected Matrix EffectiveGradientTransform
         {
             get
@@ -209,6 +212,7 @@ namespace Svg
 
             return blend;
         }
+#endif
 
         protected void LoadStops(SvgVisualElement parent)
         {

--- a/Source/Painting/SvgLinearGradientServer.cs
+++ b/Source/Painting/SvgLinearGradientServer.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.Linq;
 
 namespace Svg
@@ -37,6 +39,7 @@ namespace Svg
             get { return GetAttribute("y2", false, new SvgUnit(SvgUnitType.Percentage, 0f)); }
             set { Attributes["y2"] = value; }
         }
+#if !NO_SDC
 
         public override Brush GetBrush(SvgVisualElement renderingElement, ISvgRenderer renderer, float opacity, bool forStroke = false)
         {
@@ -96,7 +99,7 @@ namespace Svg
                     if (dx != 0f && dy != 0f)
                     {
                         var startX = (float)((dy * dx * (midPoint.Y - y2) + Math.Pow(dx, 2) * midPoint.X + Math.Pow(dy, 2) * x1) /
-                        (Math.Pow(dx, 2) + Math.Pow(dy, 2)));
+                                             (Math.Pow(dx, 2) + Math.Pow(dy, 2)));
                         var endY = dy * (startX - x1) / dx + y2;
                         points[0] = new PointF(startX, midPoint.Y + (midPoint.Y - endY));
                         points[1] = new PointF(midPoint.X + (midPoint.X - startX), endY);
@@ -125,6 +128,7 @@ namespace Svg
                 if (this.GradientUnits == SvgCoordinateUnits.ObjectBoundingBox) renderer.PopBoundable();
             }
         }
+#endif
 
         private SvgUnit NormalizeUnit(SvgUnit orig)
         {
@@ -141,6 +145,7 @@ namespace Svg
             End = 2
         }
 
+#if !NO_SDC
         private LinePoints PointsToMove(ISvgBoundable boundable, PointF specifiedStart, PointF specifiedEnd)
         {
             var bounds = boundable.Bounds;
@@ -157,6 +162,7 @@ namespace Svg
             return (boundable.Bounds.Contains(specifiedStart) ? LinePoints.Start : LinePoints.None) |
                    (boundable.Bounds.Contains(specifiedEnd) ? LinePoints.End : LinePoints.None);
         }
+#endif
 
         public struct GradientPoints
         {
@@ -169,6 +175,7 @@ namespace Svg
                 this.EndPoint = endPoint;
             }
         }
+#if !NO_SDC
 
         private GradientPoints ExpandGradient(ISvgBoundable boundable, PointF specifiedStart, PointF specifiedEnd)
         {
@@ -212,6 +219,7 @@ namespace Svg
 
             return new GradientPoints(effectiveStart, effectiveEnd);
         }
+#endif
 
         private IList<PointF> CandidateIntersections(RectangleF bounds, PointF p1, PointF p2)
         {
@@ -256,6 +264,7 @@ namespace Svg
 
             return results;
         }
+#if !NO_SDC
 
         private ColorBlend CalculateColorBlend(ISvgRenderer renderer, float opacity, PointF specifiedStart, PointF effectiveStart, PointF specifiedEnd, PointF effectiveEnd)
         {
@@ -378,6 +387,7 @@ namespace Svg
 
             return colorBlend;
         }
+#endif
 
         private static PointF CalculateClosestIntersectionPoint(PointF sourcePoint, IList<PointF> targetPoints)
         {

--- a/Source/Painting/SvgMarker.cs
+++ b/Source/Painting/SvgMarker.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.Linq;
 using Svg.DataTypes;
 
@@ -115,18 +117,20 @@ namespace Svg
             }
         }
 
+#if !NO_SDC
         public override System.Drawing.Drawing2D.GraphicsPath Path(ISvgRenderer renderer)
         {
             if (MarkerElement != null)
                 return MarkerElement.Path(renderer);
             return null;
         }
+#endif
 
         public override SvgElement DeepCopy()
         {
             return DeepCopy<SvgMarker>();
         }
-
+#if !NO_SDC
         /// <summary>
         /// Render this marker using the slope of the given line segment
         /// </summary>
@@ -205,9 +209,9 @@ namespace Svg
                                     transMatrix.Scale(MarkerWidth, MarkerHeight);
                                     var strokeWidth = pOwner.StrokeWidth.ToDeviceValue(pRenderer, UnitRenderingType.Other, this);
                                     transMatrix.Translate(AdjustForViewBoxWidth(-RefX.ToDeviceValue(pRenderer, UnitRenderingType.Horizontal, this) *
-                                                            strokeWidth),
-                                                          AdjustForViewBoxHeight(-RefY.ToDeviceValue(pRenderer, UnitRenderingType.Vertical, this) *
-                                                            strokeWidth));
+                                            strokeWidth),
+                                        AdjustForViewBoxHeight(-RefY.ToDeviceValue(pRenderer, UnitRenderingType.Vertical, this) *
+                                                               strokeWidth));
                                 }
                                 else
                                 {
@@ -216,12 +220,12 @@ namespace Svg
                                     //        But use this until the TODOs from AdjustForViewBoxWidth and AdjustForViewBoxHeight are done.
                                     //  MORE see Unit Test "MakerEndTest.TestArrowCodeCreation()"
                                     transMatrix.Translate(-RefX.ToDeviceValue(pRenderer, UnitRenderingType.Horizontal, this),
-                                                         -RefY.ToDeviceValue(pRenderer, UnitRenderingType.Vertical, this));
+                                        -RefY.ToDeviceValue(pRenderer, UnitRenderingType.Vertical, this));
                                 }
                                 break;
                             case SvgMarkerUnits.UserSpaceOnUse:
                                 transMatrix.Translate(-RefX.ToDeviceValue(pRenderer, UnitRenderingType.Horizontal, this),
-                                                      -RefY.ToDeviceValue(pRenderer, UnitRenderingType.Vertical, this));
+                                    -RefY.ToDeviceValue(pRenderer, UnitRenderingType.Vertical, this));
                                 break;
                         }
 
@@ -287,6 +291,7 @@ namespace Svg
             }
             return (pRet);
         }
+#endif
 
         /// <summary>
         /// Adjust the given value to account for the width of the viewbox in the viewport

--- a/Source/Painting/SvgPaintServer.cs
+++ b/Source/Painting/SvgPaintServer.cs
@@ -3,7 +3,9 @@ using System.ComponentModel;
 using System.Collections.Generic;
 using System.Text;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg
 {
@@ -29,6 +31,7 @@ namespace Svg
         /// An unspecified <see cref="SvgPaintServer"/>.
         /// </summary>
         public static readonly SvgPaintServer NotSet = new SvgColourServer();
+#if !NO_SDC
 
         /// <summary>
         /// Renders the <see cref="SvgElement"/> and contents to the specified <see cref="ISvgRenderer"/> object.
@@ -47,6 +50,7 @@ namespace Svg
         /// <param name="opacity">The opacity of the brush.</param>
         /// <param name="forStroke">Not used.</param>
         public abstract Brush GetBrush(SvgVisualElement styleOwner, ISvgRenderer renderer, float opacity, bool forStroke = false);
+#endif
 
         /// <summary>
         /// Returns a <see cref="T:System.String"/> that represents the current <see cref="T:System.Object"/>.

--- a/Source/Painting/SvgPatternServer.cs
+++ b/Source/Painting/SvgPatternServer.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.Linq;
 using Svg.Transforms;
 
@@ -127,6 +129,7 @@ namespace Svg
             set { Attributes["patternTransform"] = value; }
         }
 
+#if !NO_SDC
         private Matrix EffectivePatternTransform
         {
             get
@@ -245,6 +248,7 @@ namespace Svg
                     renderer.PopBoundable();
             }
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Painting/SvgRadialGradientServer.cs
+++ b/Source/Painting/SvgRadialGradientServer.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Drawing;
 using System.Collections.Generic;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.Linq;
 
 namespace Svg
@@ -71,6 +73,7 @@ namespace Svg
                     new SvgUnit(SvgUnitType.User, orig.Value / 100f) :
                     orig);
         }
+#if !NO_SDC
 
         public override Brush GetBrush(SvgVisualElement renderingElement, ISvgRenderer renderer, float opacity, bool forStroke = false)
         {
@@ -83,9 +86,9 @@ namespace Svg
 
                 // Calculate the path and transform it appropriately
                 var center = new PointF(NormalizeUnit(CenterX).ToDeviceValue(renderer, UnitRenderingType.Horizontal, this),
-                                        NormalizeUnit(CenterY).ToDeviceValue(renderer, UnitRenderingType.Vertical, this));
+                    NormalizeUnit(CenterY).ToDeviceValue(renderer, UnitRenderingType.Vertical, this));
                 var focals = new PointF[] {new PointF(NormalizeUnit(FocalX).ToDeviceValue(renderer, UnitRenderingType.Horizontal, this),
-                                                      NormalizeUnit(FocalY).ToDeviceValue(renderer, UnitRenderingType.Vertical, this)) };
+                    NormalizeUnit(FocalY).ToDeviceValue(renderer, UnitRenderingType.Vertical, this)) };
                 var specifiedRadius = NormalizeUnit(Radius).ToDeviceValue(renderer, UnitRenderingType.Other, this);
                 var path = new GraphicsPath();
                 path.AddEllipse(
@@ -205,10 +208,10 @@ namespace Svg
                 {
                     var previousPoints = new PointF[]
                     {
-                                                new PointF(points[0].X, points[0].Y),
-                                                new PointF(points[1].X, points[1].Y),
-                                                new PointF(points[2].X, points[2].Y),
-                                                new PointF(points[3].X, points[3].Y)
+                        new PointF(points[0].X, points[0].Y),
+                        new PointF(points[1].X, points[1].Y),
+                        new PointF(points[2].X, points[2].Y),
+                        new PointF(points[3].X, points[3].Y)
                     };
 
                     transform.TransformPoints(points);
@@ -252,7 +255,7 @@ namespace Svg
             rightPoints.Sort((p, q) => p.Y.CompareTo(q.Y));
 
             var point = new PointF((leftPoints.Last().X + rightPoints.Last().X) / 2,
-                                   (leftPoints.Last().Y + rightPoints.Last().Y) / 2);
+                (leftPoints.Last().Y + rightPoints.Last().Y) / 2);
             leftPoints.Add(point);
             rightPoints.Add(point);
             point = new PointF(point.X, bounds.Bottom);
@@ -366,6 +369,7 @@ namespace Svg
 
             return colorBlend;
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Paths/SvgArcSegment.cs
+++ b/Source/Paths/SvgArcSegment.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg.Pathing
 {
@@ -42,6 +44,7 @@ namespace Svg.Pathing
             return DoublePI - (ta - tb);
         }
 
+#if !NO_SDC
         public override PointF AddToPath(GraphicsPath graphicsPath, PointF start, SvgPathSegmentList parent)
         {
             var end = ToAbsolute(End, IsRelative, start);
@@ -135,6 +138,13 @@ namespace Svg.Pathing
             return end;
         }
 
+        [Obsolete("Use new AddToPath.")]
+        public override void AddToPath(GraphicsPath graphicsPath)
+        {
+            AddToPath(graphicsPath, Start, null);
+        }
+#endif
+
         public override string ToString()
         {
             var arcFlag = Size == SvgArcSize.Large ? "1" : "0";
@@ -147,11 +157,6 @@ namespace Svg.Pathing
             : this(radiusX, radiusY, angle, size, sweep, false, end)
         {
             Start = start;
-        }
-        [Obsolete("Use new AddToPath.")]
-        public override void AddToPath(GraphicsPath graphicsPath)
-        {
-            AddToPath(graphicsPath, Start, null);
         }
     }
 

--- a/Source/Paths/SvgArcSegment.cs
+++ b/Source/Paths/SvgArcSegment.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Drawing;
 #if !NO_SDC
 using System.Drawing.Drawing2D;

--- a/Source/Paths/SvgClosePathSegment.cs
+++ b/Source/Paths/SvgClosePathSegment.cs
@@ -1,5 +1,7 @@
-﻿using System.Drawing;
+using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg.Pathing
 {
@@ -10,6 +12,7 @@ namespace Svg.Pathing
         {
         }
 
+#if !NO_SDC
         public override PointF AddToPath(GraphicsPath graphicsPath, PointF start, SvgPathSegmentList parent)
         {
             graphicsPath.CloseFigure();
@@ -23,6 +26,7 @@ namespace Svg.Pathing
                 }
             return end;
         }
+#endif
 
         public override string ToString()
         {

--- a/Source/Paths/SvgClosePathSegment.cs
+++ b/Source/Paths/SvgClosePathSegment.cs
@@ -26,6 +26,12 @@ namespace Svg.Pathing
                 }
             return end;
         }
+
+        [System.Obsolete("Use new AddToPath.")]
+        public override void AddToPath(GraphicsPath graphicsPath)
+        {
+            AddToPath(graphicsPath, Start, null);
+        }
 #endif
 
         public override string ToString()
@@ -37,11 +43,6 @@ namespace Svg.Pathing
         public SvgClosePathSegment()
             : this(true)
         {
-        }
-        [System.Obsolete("Use new AddToPath.")]
-        public override void AddToPath(GraphicsPath graphicsPath)
-        {
-            AddToPath(graphicsPath, Start, null);
         }
     }
 }

--- a/Source/Paths/SvgCubicCurveSegment.cs
+++ b/Source/Paths/SvgCubicCurveSegment.cs
@@ -1,5 +1,7 @@
 ﻿using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg.Pathing
 {
@@ -20,6 +22,7 @@ namespace Svg.Pathing
         {
         }
 
+#if !NO_SDC
         public override PointF AddToPath(GraphicsPath graphicsPath, PointF start, SvgPathSegmentList parent)
         {
             var firstControlPoint = FirstControlPoint;
@@ -42,6 +45,13 @@ namespace Svg.Pathing
             return end;
         }
 
+        [System.Obsolete("Use new AddToPath.")]
+        public override void AddToPath(GraphicsPath graphicsPath)
+        {
+            AddToPath(graphicsPath, Start, null);
+        }
+#endif
+
         public override string ToString()
         {
             if (float.IsNaN(FirstControlPoint.X) || float.IsNaN(FirstControlPoint.Y))
@@ -55,11 +65,6 @@ namespace Svg.Pathing
             : this(false, firstControlPoint, secondControlPoint, end)
         {
             Start = start;
-        }
-        [System.Obsolete("Use new AddToPath.")]
-        public override void AddToPath(GraphicsPath graphicsPath)
-        {
-            AddToPath(graphicsPath, Start, null);
         }
     }
 }

--- a/Source/Paths/SvgCubicCurveSegment.cs
+++ b/Source/Paths/SvgCubicCurveSegment.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+using System.Drawing;
 #if !NO_SDC
 using System.Drawing.Drawing2D;
 #endif

--- a/Source/Paths/SvgLineSegment.cs
+++ b/Source/Paths/SvgLineSegment.cs
@@ -1,5 +1,7 @@
 ﻿using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg.Pathing
 {
@@ -10,12 +12,20 @@ namespace Svg.Pathing
         {
         }
 
+#if !NO_SDC
         public override PointF AddToPath(GraphicsPath graphicsPath, PointF start, SvgPathSegmentList parent)
         {
             var end = ToAbsolute(End, IsRelative, start);
             graphicsPath.AddLine(start, end);
             return end;
         }
+
+        [System.Obsolete("Use new AddToPath.")]
+        public override void AddToPath(GraphicsPath graphicsPath)
+        {
+            AddToPath(graphicsPath, Start, null);
+        }
+#endif
 
         public override string ToString()
         {
@@ -32,11 +42,6 @@ namespace Svg.Pathing
             : this(false, end)
         {
             Start = start;
-        }
-        [System.Obsolete("Use new AddToPath.")]
-        public override void AddToPath(GraphicsPath graphicsPath)
-        {
-            AddToPath(graphicsPath, Start, null);
         }
     }
 }

--- a/Source/Paths/SvgLineSegment.cs
+++ b/Source/Paths/SvgLineSegment.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+using System.Drawing;
 #if !NO_SDC
 using System.Drawing.Drawing2D;
 #endif

--- a/Source/Paths/SvgMoveToSegment.cs
+++ b/Source/Paths/SvgMoveToSegment.cs
@@ -1,5 +1,7 @@
 ﻿using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg.Pathing
 {
@@ -10,11 +12,19 @@ namespace Svg.Pathing
         {
         }
 
+#if !NO_SDC
         public override PointF AddToPath(GraphicsPath graphicsPath, PointF start, SvgPathSegmentList parent)
         {
             graphicsPath.StartFigure();
             return ToAbsolute(End, IsRelative, start);
         }
+
+        [System.Obsolete("Use new AddToPath.")]
+        public override void AddToPath(GraphicsPath graphicsPath)
+        {
+            AddToPath(graphicsPath, Start, null);
+        }
+#endif
 
         public override string ToString()
         {
@@ -26,11 +36,6 @@ namespace Svg.Pathing
             : this(false, moveTo)
         {
             Start = moveTo;
-        }
-        [System.Obsolete("Use new AddToPath.")]
-        public override void AddToPath(GraphicsPath graphicsPath)
-        {
-            AddToPath(graphicsPath, Start, null);
         }
     }
 }

--- a/Source/Paths/SvgMoveToSegment.cs
+++ b/Source/Paths/SvgMoveToSegment.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+using System.Drawing;
 #if !NO_SDC
 using System.Drawing.Drawing2D;
 #endif

--- a/Source/Paths/SvgPath.cs
+++ b/Source/Paths/SvgPath.cs
@@ -1,5 +1,7 @@
 ﻿using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using Svg.Pathing;
 
 namespace Svg
@@ -10,7 +12,9 @@ namespace Svg
     [SvgElement("path")]
     public partial class SvgPath : SvgMarkerElement, ISvgPathElement
     {
+#if !NO_SDC
         private GraphicsPath _path;
+#endif
 
         /// <summary>
         /// Gets or sets a <see cref="SvgPathSegmentList"/> of path data.
@@ -40,6 +44,7 @@ namespace Svg
             set { Attributes["pathLength"] = value; }
         }
 
+#if !NO_SDC
         /// <summary>
         /// Gets the <see cref="GraphicsPath"/> for this element.
         /// </summary>
@@ -84,6 +89,7 @@ namespace Svg
             }
             return _path;
         }
+#endif
 
         public void OnPathUpdated()
         {

--- a/Source/Paths/SvgPathSegment.cs
+++ b/Source/Paths/SvgPathSegment.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg.Pathing
 {
@@ -23,6 +25,7 @@ namespace Svg.Pathing
             End = end;
         }
 
+#if !NO_SDC
         protected static PointF Reflect(PointF point, PointF mirror)
         {
             var dx = Math.Abs(mirror.X - point.X);
@@ -51,6 +54,11 @@ namespace Svg.Pathing
 
         public abstract PointF AddToPath(GraphicsPath graphicsPath, PointF start, SvgPathSegmentList parent);
 
+        [Obsolete("Use new AddToPath.")]
+        public abstract void AddToPath(GraphicsPath graphicsPath);
+
+#endif
+
         public SvgPathSegment Clone()
         {
             return MemberwiseClone() as SvgPathSegment;
@@ -58,7 +66,5 @@ namespace Svg.Pathing
 
         [Obsolete("Will be removed.")]
         public PointF Start { get; set; }
-        [Obsolete("Use new AddToPath.")]
-        public abstract void AddToPath(GraphicsPath graphicsPath);
     }
 }

--- a/Source/Paths/SvgPathSegment.cs
+++ b/Source/Paths/SvgPathSegment.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Drawing;
 #if !NO_SDC
 using System.Drawing.Drawing2D;

--- a/Source/Paths/SvgQuadraticCurveSegment.cs
+++ b/Source/Paths/SvgQuadraticCurveSegment.cs
@@ -1,5 +1,7 @@
 ﻿using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg.Pathing
 {
@@ -34,6 +36,7 @@ namespace Svg.Pathing
             return new PointF(x2, y2);
         }
 
+#if !NO_SDC
         private static PointF CalculateControlPoint(PointF start, PointF firstControlPoint)
         {
             var x1 = (firstControlPoint.X * 3 - start.X) / 2;
@@ -66,6 +69,13 @@ namespace Svg.Pathing
             return end;
         }
 
+        [System.Obsolete("Use new AddToPath.")]
+        public override void AddToPath(GraphicsPath graphicsPath)
+        {
+            AddToPath(graphicsPath, Start, null);
+        }
+#endif
+
         public override string ToString()
         {
             if (float.IsNaN(ControlPoint.X) || float.IsNaN(ControlPoint.Y))
@@ -79,11 +89,6 @@ namespace Svg.Pathing
             : this(false, controlPoint, end)
         {
             Start = start;
-        }
-        [System.Obsolete("Use new AddToPath.")]
-        public override void AddToPath(GraphicsPath graphicsPath)
-        {
-            AddToPath(graphicsPath, Start, null);
         }
     }
 }

--- a/Source/Paths/SvgQuadraticCurveSegment.cs
+++ b/Source/Paths/SvgQuadraticCurveSegment.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+using System.Drawing;
 #if !NO_SDC
 using System.Drawing.Drawing2D;
 #endif

--- a/Source/Rendering/IGraphicsProvider.cs
+++ b/Source/Rendering/IGraphicsProvider.cs
@@ -4,6 +4,8 @@ namespace Svg
 {
     public interface IGraphicsProvider
     {
+#if !NO_SDC
         Graphics GetGraphics();
+#endif
     }
 }

--- a/Source/Rendering/ISvgRenderer.cs
+++ b/Source/Rendering/ISvgRenderer.cs
@@ -1,12 +1,15 @@
 ﻿using System;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg
 {
     public interface ISvgRenderer : IDisposable
     {
         float DpiY { get; }
+#if !NO_SDC
         void DrawImage(Image image, RectangleF destRect, RectangleF srcRect, GraphicsUnit graphicsUnit);
         void DrawImageUnscaled(Image image, Point location);
         void DrawPath(Pen pen, GraphicsPath path);
@@ -22,5 +25,6 @@ namespace Svg
         Matrix Transform { get; set; }
         void TranslateTransform(float dx, float dy, MatrixOrder order = MatrixOrder.Append);
         void DrawImage(Image image, RectangleF destRect, RectangleF srcRect, GraphicsUnit graphicsUnit, float opacity);
+#endif
     }
 }

--- a/Source/Rendering/SvgRenderer.cs
+++ b/Source/Rendering/SvgRenderer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if !NO_SDC
+using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
@@ -164,3 +165,4 @@ namespace Svg
         }
     }
 }
+#endif

--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.IO;
 using System.Text;
 using System.Xml;
@@ -187,8 +189,10 @@ namespace Svg
         /// Gets or sets an external Cascading Style Sheet (CSS)
         /// </summary>
         public string ExternalCSSHref { get; set; }
+#if !NO_SDC
 
         internal SvgFontManager FontManager { get; private set; }
+#endif
 
         #region ITypeDescriptorContext Members
 
@@ -274,7 +278,9 @@ namespace Svg
         {
             try
             {
+#if !NO_SDC
                 using (var matrix = new Matrix(0f, 0f, 0f, 0f, 0f, 0f)) { }
+#endif
             }
             // GDI+ loading errors will result in TypeInitializationExceptions,
             // for readability we will catch and wrap the error
@@ -581,6 +587,7 @@ namespace Svg
             var reader = new SvgNodeReader(document.DocumentElement, null);
             return Create<SvgDocument>(reader);
         }
+#if !NO_SDC
 
         public static Bitmap OpenAsBitmap(string path)
         {
@@ -746,6 +753,7 @@ namespace Svg
 
             return bitmap;
         }
+#endif
 
         /// <summary>
         /// If both or one of raster height and width is not given (0), calculate that missing value from original SVG size

--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.Linq;
 using System.Reflection;
 using System.Xml;
@@ -41,8 +43,10 @@ namespace Svg
         private EventHandlerList _eventHandlers;
         private SvgElementCollection _children;
         private static readonly object _loadEventKey = new object();
+#if !NO_SDC
         private Matrix _graphicsTransform;
         private Region _graphicsClip;
+#endif
         private SvgCustomAttributeCollection _customAttributes;
         private List<ISvgNode> _nodes = new List<ISvgNode>();
 
@@ -335,6 +339,7 @@ namespace Svg
         {
             get { return this._customAttributes; }
         }
+#if !NO_SDC
 
         /// <summary>
         /// Applies the required transforms to <see cref="ISvgRenderer"/>.
@@ -396,6 +401,7 @@ namespace Svg
         {
             PopTransforms(renderer);
         }
+#endif
 
         /// <summary>
         /// Gets or sets the element transforms.
@@ -415,6 +421,7 @@ namespace Svg
             }
         }
 
+#if !NO_SDC
         /// <summary>
         /// Transforms the given rectangle with the set transformation, if any.
         /// Can be applied to bounds calculated without considering the element transformation.
@@ -435,6 +442,7 @@ namespace Svg
             }
             return bounds;
         }
+#endif
 
         /// <summary>
         /// Gets or sets the ID of the element.
@@ -579,6 +587,7 @@ namespace Svg
             throw new NotImplementedException();
         }
 
+#if !NO_SDC
         /// <summary>
         /// Renders this element to the <see cref="ISvgRenderer"/>.
         /// </summary>
@@ -587,6 +596,7 @@ namespace Svg
         {
             Render(renderer);
         }
+#endif
 
         /// <summary>Derrived classes may decide that the element should not be written. For example, the text element shouldn't be written if it's empty.</summary>
         public virtual bool ShouldWriteElement()
@@ -1038,6 +1048,7 @@ namespace Svg
                 }
             }
         }
+#if !NO_SDC
 
         /// <summary>
         /// Renders the <see cref="SvgElement"/> and contents to the specified <see cref="ISvgRenderer"/> object.
@@ -1164,6 +1175,7 @@ namespace Svg
 
             return ret;
         }
+#endif
 
         /// <summary>
         /// Creates a new object that is a copy of the current instance.
@@ -1589,6 +1601,8 @@ namespace Svg
         SvgElementCollection Children { get; }
         IList<ISvgNode> Nodes { get; }
 
+#if !NO_SDC
         void Render(ISvgRenderer renderer);
+#endif
     }
 }

--- a/Source/SvgElementStyle.cs
+++ b/Source/SvgElementStyle.cs
@@ -387,6 +387,7 @@ namespace Svg
                 IsPathDirty = true;
             }
         }
+#if !NO_SDC
 
         /// <summary>
         /// Get the font information based on data stored with the text object or inherited from the parent.
@@ -509,5 +510,6 @@ namespace Svg
             // No valid font family found from the list requested.
             return System.Drawing.FontFamily.GenericSansSerif;
         }
+#endif
     }
 }

--- a/Source/SvgFontManager.cs
+++ b/Source/SvgFontManager.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !NO_SDC
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Text;
@@ -107,3 +108,4 @@ namespace Svg
         }
     }
 }
+#endif

--- a/Source/Text/GdiFontDefn.cs
+++ b/Source/Text/GdiFontDefn.cs
@@ -1,14 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.Linq;
 
 namespace Svg
 {
     public class GdiFontDefn : IFontDefn
     {
+#if !NO_SDC
         private readonly Font _font;
+
         private float _ppi;
 
         public float Size
@@ -56,7 +60,7 @@ namespace Svg
                 {
                     var numberOfChar = Math.Min(32, text.Length - 32 * s);
                     format.SetMeasurableCharacterRanges((from r in Enumerable.Range(32 * s, numberOfChar)
-                                                         select new CharacterRange(r, 1)).ToArray());
+                        select new CharacterRange(r, 1)).ToArray());
                     regions.AddRange(from r in g.MeasureCharacterRanges(text, _font, layoutRect, format) select r.GetBounds(g));
                 }
             }
@@ -86,10 +90,13 @@ namespace Svg
             }
             return provider.GetGraphics();
         }
+#endif
 
         public void Dispose()
         {
+#if !NO_SDC
             _font.Dispose();
+#endif
         }
     }
 }

--- a/Source/Text/IFontDefn.cs
+++ b/Source/Text/IFontDefn.cs
@@ -3,17 +3,21 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg
 {
     public interface IFontDefn : IDisposable
     {
+#if !NO_SDC
         float Size { get; }
         float SizeInPoints { get; }
         void AddStringToPath(ISvgRenderer renderer, GraphicsPath path, string text, PointF location);
         float Ascent(ISvgRenderer renderer);
         IList<RectangleF> MeasureCharacters(ISvgRenderer renderer, string text);
         SizeF MeasureString(ISvgRenderer renderer, string text);
+#endif
     }
 }

--- a/Source/Text/PathStatistics.cs
+++ b/Source/Text/PathStatistics.cs
@@ -2,11 +2,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.Drawing;
 
 namespace Svg
 {
+#if !NO_SDC
     public class PathStatistics
     {
         private const double GqBreak_TwoPoint = 0.57735026918962573;
@@ -115,7 +118,7 @@ namespace Svg
                 offset -= StartOffset;
                 if (offset < 0 || offset > _length) throw new ArgumentOutOfRangeException();
                 point = new PointF((float)(_start.X + (offset / _length) * (_end.X - _start.X)),
-                                   (float)(_start.Y + (offset / _length) * (_end.Y - _start.Y)));
+                    (float)(_start.Y + (offset / _length) * (_end.Y - _start.Y)));
                 rotation = (float)_rotation;
             }
         }
@@ -240,16 +243,16 @@ namespace Svg
             private PointF CubicBezierCurve(PointF p0, PointF p1, PointF p2, PointF p3, double t)
             {
                 return new PointF((float)(Math.Pow(1 - t, 3) * p0.X + 3 * Math.Pow(1 - t, 2) * t * p1.X +
-                                            3 * (1 - t) * Math.Pow(t, 2) * p2.X + Math.Pow(t, 3) * p3.X),
-                                    (float)(Math.Pow(1 - t, 3) * p0.Y + 3 * Math.Pow(1 - t, 2) * t * p1.Y +
-                                            3 * (1 - t) * Math.Pow(t, 2) * p2.Y + Math.Pow(t, 3) * p3.Y));
+                                          3 * (1 - t) * Math.Pow(t, 2) * p2.X + Math.Pow(t, 3) * p3.X),
+                    (float)(Math.Pow(1 - t, 3) * p0.Y + 3 * Math.Pow(1 - t, 2) * t * p1.Y +
+                            3 * (1 - t) * Math.Pow(t, 2) * p2.Y + Math.Pow(t, 3) * p3.Y));
             }
 
             /// <remarks>http://www.cs.mtu.edu/~shene/COURSES/cs3621/NOTES/spline/Bezier/bezier-der.html</remarks>
             private PointF CubicBezierDerivative(PointF p0, PointF p1, PointF p2, PointF p3, double t)
             {
                 return new PointF((float)(3 * Math.Pow(1 - t, 2) * (p1.X - p0.X) + 6 * (1 - t) * t * (p2.X - p1.X) + 3 * Math.Pow(t, 2) * (p3.X - p2.X)),
-                                  (float)(3 * Math.Pow(1 - t, 2) * (p1.Y - p0.Y) + 6 * (1 - t) * t * (p2.Y - p1.Y) + 3 * Math.Pow(t, 2) * (p3.Y - p2.Y)));
+                    (float)(3 * Math.Pow(1 - t, 2) * (p1.Y - p0.Y) + 6 * (1 - t) * t * (p2.Y - p1.Y) + 3 * Math.Pow(t, 2) * (p3.Y - p2.Y)));
             }
 
 
@@ -260,4 +263,5 @@ namespace Svg
             }
         }
     }
+#endif
 }

--- a/Source/Text/SvgFont.cs
+++ b/Source/Text/SvgFont.cs
@@ -56,8 +56,10 @@ namespace Svg
             return base.DeepCopy<SvgFont>();
         }
 
+#if !NO_SDC
         protected override void Render(ISvgRenderer renderer)
         {
         }
+#endif
     }
 }

--- a/Source/Text/SvgFontDefn.cs
+++ b/Source/Text/SvgFontDefn.cs
@@ -3,12 +3,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg
 {
     public class SvgFontDefn : IFontDefn
     {
+#if !NO_SDC
         private SvgFont _font;
         private float _emScale;
         private float _ppi;
@@ -42,14 +45,14 @@ namespace Svg
             return _ppi / 72f * baselineOffset;
         }
 
-        public IList<System.Drawing.RectangleF> MeasureCharacters(ISvgRenderer renderer, string text)
+        public IList<RectangleF> MeasureCharacters(ISvgRenderer renderer, string text)
         {
             var result = new List<RectangleF>();
             using (var path = GetPath(renderer, text, result, false)) { }
             return result;
         }
 
-        public System.Drawing.SizeF MeasureString(ISvgRenderer renderer, string text)
+        public SizeF MeasureString(ISvgRenderer renderer, string text)
         {
             var result = new List<RectangleF>();
             using (var path = GetPath(renderer, text, result, true)) { }
@@ -130,10 +133,13 @@ namespace Svg
             if (_kerning == null) _kerning = _font.Descendants().OfType<SvgKern>().ToDictionary(k => k.Glyph1 + "|" + k.Glyph2);
         }
 
+#endif
         public void Dispose()
         {
+#if !NO_SDC
             _glyphs = null;
             _kerning = null;
+#endif
         }
     }
 }

--- a/Source/Text/SvgGlyph.cs
+++ b/Source/Text/SvgGlyph.cs
@@ -1,5 +1,7 @@
-﻿using System.Drawing;
+using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.Linq;
 using Svg.Pathing;
 
@@ -8,7 +10,9 @@ namespace Svg
     [SvgElement("glyph")]
     public partial class SvgGlyph : SvgPathBasedElement, ISvgPathElement
     {
+#if !NO_SDC
         private GraphicsPath _path;
+#endif
 
         /// <summary>
         /// Gets or sets a <see cref="SvgPathSegmentList"/> of path data.
@@ -69,6 +73,7 @@ namespace Svg
             set { Attributes["vert-origin-y"] = value; }
         }
 
+#if !NO_SDC
         /// <summary>
         /// Gets the <see cref="GraphicsPath"/> for this element.
         /// </summary>
@@ -89,6 +94,7 @@ namespace Svg
             }
             return _path;
         }
+#endif
 
         public void OnPathUpdated()
         {

--- a/Source/Text/SvgTextBase.cs
+++ b/Source/Text/SvgTextBase.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -250,6 +252,7 @@ namespace Svg
         {
             return this.Text;
         }
+#if !NO_SDC
 
         /// <summary>
         /// Gets the bounds of the element.
@@ -426,6 +429,7 @@ namespace Svg
             _path = path;
             this.IsPathDirty = false;
         }
+#endif
 
         private static readonly Regex MultipleSpaces = new Regex(@" {2,}", RegexOptions.Compiled);
 
@@ -548,6 +552,7 @@ namespace Svg
                 newObj._rotations.Add(rotation);
             return newObj;
         }
+#if !NO_SDC
 
         private class FontBoundable : ISvgBoundable
         {
@@ -755,7 +760,7 @@ namespace Svg
 
                         xTextStart = xTextStart.Equals(Current.X) ? _xAnchor : xTextStart;
                         DrawStringOnCurrPath(value[i].ToString(), font, new PointF(_xAnchor, yPos),
-                                             fontBaselineHeight, (rotations.Count > i ? rotations[i] : rotations.LastOrDefault()));
+                            fontBaselineHeight, (rotations.Count > i ? rotations[i] : rotations.LastOrDefault()));
                     }
 
                     // Render any remaining characters
@@ -788,7 +793,7 @@ namespace Svg
                             {
                                 xTextStart = xTextStart.Equals(Current.X) ? xPos : xTextStart;
                                 DrawStringOnCurrPath(value[i].ToString(), font, new PointF(xPos, yPos),
-                                                     fontBaselineHeight, (rotations.Count > i ? rotations[i] : rotations.LastOrDefault()));
+                                    fontBaselineHeight, (rotations.Count > i ? rotations[i] : rotations.LastOrDefault()));
                             }
                             else
                             {
@@ -798,7 +803,7 @@ namespace Svg
                                 {
                                     pathStats.LocationAngleAtOffset(xPos + halfWidth, out pathPoint, out rotation);
                                     pathPoint = new PointF((float)(pathPoint.X - halfWidth * Math.Cos(rotation * Math.PI / 180) - (float)pathScale * yPos * Math.Sin(rotation * Math.PI / 180)),
-                                                           (float)(pathPoint.Y - halfWidth * Math.Sin(rotation * Math.PI / 180) + (float)pathScale * yPos * Math.Cos(rotation * Math.PI / 180)));
+                                        (float)(pathPoint.Y - halfWidth * Math.Sin(rotation * Math.PI / 180) + (float)pathScale * yPos * Math.Cos(rotation * Math.PI / 180)));
                                     xTextStart = xTextStart.Equals(Current.X) ? pathPoint.X : xTextStart;
                                     DrawStringOnCurrPath(value[i].ToString(), font, pathPoint, fontBaselineHeight, rotation);
                                 }
@@ -821,10 +826,10 @@ namespace Svg
                     {
                         xPos += (xOffsets.Count > lastIndividualChar ? xOffsets[lastIndividualChar] : 0);
                         yPos = (yAnchors.Count > lastIndividualChar ? yAnchors[lastIndividualChar] : yPos) +
-                                (yOffsets.Count > lastIndividualChar ? yOffsets[lastIndividualChar] : 0);
+                               (yOffsets.Count > lastIndividualChar ? yOffsets[lastIndividualChar] : 0);
                         xTextStart = xTextStart.Equals(Current.X) ? xPos : xTextStart;
                         DrawStringOnCurrPath(value.Substring(lastIndividualChar), font, new PointF(xPos, yPos),
-                                             fontBaselineHeight, rotations.LastOrDefault());
+                            fontBaselineHeight, rotations.LastOrDefault());
                         var bounds = font.MeasureString(this.Renderer, value.Substring(lastIndividualChar));
                         xPos += bounds.Width;
                     }
@@ -993,6 +998,7 @@ namespace Svg
                 return results;
             }
         }
+#endif
 
         /// <summary>Empty text elements are not legal - only write this element if it has children.</summary>
         public override bool ShouldWriteElement()

--- a/Source/Text/SvgTextPath.cs
+++ b/Source/Text/SvgTextPath.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg
 {
@@ -49,6 +51,7 @@ namespace Svg
             get { return GetAttribute<Uri>("href", false); }
             set { Attributes["href"] = value; }
         }
+#if !NO_SDC
 
         protected override GraphicsPath GetBaselinePath(ISvgRenderer renderer)
         {
@@ -66,6 +69,7 @@ namespace Svg
             if (path == null) return 0;
             return path.PathLength;
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Text/SvgTextRef.cs
+++ b/Source/Text/SvgTextRef.cs
@@ -14,6 +14,7 @@ namespace Svg
             set { Attributes["href"] = value; }
         }
 
+#if !NO_SDC
         internal override IEnumerable<ISvgNode> GetContentNodes()
         {
             var refText = this.OwnerDocument.IdManager.GetElementById(this.ReferencedElement) as SvgTextBase;
@@ -32,6 +33,7 @@ namespace Svg
 
             return contentNodes;
         }
+#endif
 
         public override SvgElement DeepCopy()
         {

--- a/Source/Transforms/ISvgTransformable.cs
+++ b/Source/Transforms/ISvgTransformable.cs
@@ -11,6 +11,7 @@ namespace Svg
         /// Gets or sets an <see cref="SvgTransformCollection"/> of element transforms.
         /// </summary>
         SvgTransformCollection Transforms { get; set; }
+#if !NO_SDC
         /// <summary>
         /// Applies the required transforms to <see cref="ISvgRenderer"/>.
         /// </summary>
@@ -21,5 +22,6 @@ namespace Svg
         /// </summary>
         /// <param name="renderer">The <see cref="ISvgRenderer"/> that should have transforms removed.</param>
         void PopTransforms(ISvgRenderer renderer);
+#endif
     }
 }

--- a/Source/Transforms/SvgMatrix.cs
+++ b/Source/Transforms/SvgMatrix.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.Globalization;
 
 namespace Svg.Transforms
@@ -11,6 +13,7 @@ namespace Svg.Transforms
     {
         public List<float> Points { get; set; }
 
+#if !NO_SDC
         public override Matrix Matrix
         {
             get
@@ -25,6 +28,7 @@ namespace Svg.Transforms
                 );
             }
         }
+#endif
 
         public override string WriteToString()
         {

--- a/Source/Transforms/SvgRotate.cs
+++ b/Source/Transforms/SvgRotate.cs
@@ -1,4 +1,6 @@
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.Globalization;
 
 namespace Svg.Transforms
@@ -11,6 +13,7 @@ namespace Svg.Transforms
 
         public float CenterY { get; set; }
 
+#if !NO_SDC
         public override Matrix Matrix
         {
             get
@@ -22,6 +25,7 @@ namespace Svg.Transforms
                 return matrix;
             }
         }
+#endif
 
         public override string WriteToString()
         {

--- a/Source/Transforms/SvgScale.cs
+++ b/Source/Transforms/SvgScale.cs
@@ -1,4 +1,6 @@
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.Globalization;
 
 namespace Svg.Transforms
@@ -9,6 +11,7 @@ namespace Svg.Transforms
 
         public float Y { get; set; }
 
+#if !NO_SDC
         public override Matrix Matrix
         {
             get
@@ -18,6 +21,7 @@ namespace Svg.Transforms
                 return matrix;
             }
         }
+#endif
 
         public override string WriteToString()
         {

--- a/Source/Transforms/SvgShear.cs
+++ b/Source/Transforms/SvgShear.cs
@@ -1,4 +1,6 @@
-﻿using System.Drawing.Drawing2D;
+﻿#if !NO_SDC
+using System.Drawing.Drawing2D;
+#endif
 using System.Globalization;
 
 namespace Svg.Transforms
@@ -12,6 +14,7 @@ namespace Svg.Transforms
 
         public float Y { get; set; }
 
+#if !NO_SDC
         public override Matrix Matrix
         {
             get
@@ -21,6 +24,7 @@ namespace Svg.Transforms
                 return matrix;
             }
         }
+#endif
 
         public override string WriteToString()
         {

--- a/Source/Transforms/SvgSkew.cs
+++ b/Source/Transforms/SvgSkew.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.Globalization;
 
 namespace Svg.Transforms
@@ -13,6 +15,7 @@ namespace Svg.Transforms
 
         public float AngleY { get; set; }
 
+#if !NO_SDC
         public override Matrix Matrix
         {
             get
@@ -22,6 +25,7 @@ namespace Svg.Transforms
                 return matrix;
             }
         }
+#endif
 
         public override string WriteToString()
         {

--- a/Source/Transforms/SvgTransform.cs
+++ b/Source/Transforms/SvgTransform.cs
@@ -1,16 +1,22 @@
 using System;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 
 namespace Svg.Transforms
 {
     public abstract class SvgTransform : ICloneable
     {
+#if !NO_SDC
         public abstract Matrix Matrix { get; }
+#endif
         public abstract string WriteToString();
 
         public abstract object Clone();
 
         #region Equals implementation
+
+#if !NO_SDC
         public override bool Equals(object obj)
         {
             var other = obj as SvgTransform;
@@ -38,6 +44,7 @@ namespace Svg.Transforms
         {
             return !(lhs == rhs);
         }
+#endif
         #endregion
 
         public override string ToString()

--- a/Source/Transforms/SvgTransformCollection.cs
+++ b/Source/Transforms/SvgTransformCollection.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.Linq;
 
 namespace Svg.Transforms
@@ -38,6 +40,7 @@ namespace Svg.Transforms
             OnTransformChanged();
         }
 
+#if !NO_SDC
         /// <summary>
         /// Multiplies all matrices
         /// </summary>
@@ -52,10 +55,11 @@ namespace Svg.Transforms
 
             return transformMatrix;
         }
+#endif
 
         public override bool Equals(object obj)
         {
-            if (Count == 0 && Count == base.Count) // default will be an empty list 
+            if (Count == 0 && Count == base.Count) // default will be an empty list
                 return true;
             return base.Equals(obj);
         }

--- a/Source/Transforms/SvgTranslate.cs
+++ b/Source/Transforms/SvgTranslate.cs
@@ -1,4 +1,6 @@
+#if !NO_SDC
 using System.Drawing.Drawing2D;
+#endif
 using System.Globalization;
 
 namespace Svg.Transforms
@@ -9,6 +11,7 @@ namespace Svg.Transforms
 
         public float Y { get; set; }
 
+#if !NO_SDC
         public override Matrix Matrix
         {
             get
@@ -18,6 +21,7 @@ namespace Svg.Transforms
                 return matrix;
             }
         }
+#endif
 
         public override string WriteToString()
         {

--- a/Source/Web/SvgHandler.cs
+++ b/Source/Web/SvgHandler.cs
@@ -4,7 +4,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Drawing;
+#if !NO_SDC
 using System.Drawing.Imaging;
+#endif
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -75,11 +77,11 @@ namespace Svg.Web
         /// <param name="result">An <see cref="T:System.IAsyncResult"/> that contains information about the status of the process.</param>
         public void EndProcessRequest(IAsyncResult result)
         {
-            
+
         }
 
         /// <summary>
-        /// The class to be used when 
+        /// The class to be used when
         /// </summary>
         protected sealed class SvgAsyncRender
         {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->
Enabled building library without System.Drawing.Common dependency by defining `NO_SDC`.

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
