### PR TITLE
Add BoundsRelativeToTop

### DIFF
--- a/Source/Basic Shapes/SvgPathBasedElement.Drawing.cs
+++ b/Source/Basic Shapes/SvgPathBasedElement.Drawing.cs
@@ -1,4 +1,4 @@
-#if !NO_SDC
+﻿#if !NO_SDC
 using System.Drawing;
 using System.Drawing.Drawing2D;
 
@@ -6,24 +6,10 @@ namespace Svg
 {
     public abstract partial class SvgPathBasedElement : SvgVisualElement
     {
-        public override RectangleF Bounds
-        {
-            get
-            {
-                var path = Path(null);
-                if (path == null)
-                    return new RectangleF();
-                if (Transforms == null || Transforms.Count == 0)
-                    return path.GetBounds();
-
-                using (path = (GraphicsPath)path.Clone())
-                using (var matrix = Transforms.GetMatrix())
-                {
-                    path.Transform(matrix);
-                    return path.GetBounds();
-                }
-            }
-        }
+        /// <inheritdoc/>
+        public override RectangleF Bounds => TransformedBoundsFromPathToClone(Path(null));
+        /// <inheritdoc/>
+        public override RectangleF BoundsRelativeToTop => TransformedBoundsPlusParentsFromPathToClone(Path(null));
     }
 }
 #endif

--- a/Source/Document Structure/SvgGroup.Drawing.cs
+++ b/Source/Document Structure/SvgGroup.Drawing.cs
@@ -1,4 +1,4 @@
-#if !NO_SDC
+﻿#if !NO_SDC
 using System.Drawing;
 using System.Drawing.Drawing2D;
 
@@ -15,38 +15,10 @@ namespace Svg
             return GetPaths(this, renderer);
         }
 
-        /// <summary>
-        /// Gets the bounds of the element.
-        /// </summary>
-        /// <value>The bounds.</value>
-        public override RectangleF Bounds
-        {
-            get
-            {
-                var r = new RectangleF();
-                foreach (var c in this.Children)
-                {
-                    if (c is SvgVisualElement)
-                    {
-                        // First it should check if rectangle is empty or it will return the wrong Bounds.
-                        // This is because when the Rectangle is Empty, the Union method adds as if the first values where X=0, Y=0
-                        if (r.IsEmpty)
-                        {
-                            r = ((SvgVisualElement)c).Bounds;
-                        }
-                        else
-                        {
-                            var childBounds = ((SvgVisualElement)c).Bounds;
-                            if (!childBounds.IsEmpty)
-                            {
-                                r = RectangleF.Union(r, childBounds);
-                            }
-                        }
-                    }
-                }
-                return r; // Don't call TransformedBounds because the child elements are already subject to transforms applied on this group
-            }
-        }
+        /// <inheritdoc/>
+        public override RectangleF Bounds => BoundsFromChildren(e => e.Bounds, TransformedBounds);
+        /// <inheritdoc/>
+        public override RectangleF BoundsRelativeToTop => BoundsFromChildren(e => e.BoundsRelativeToTop, r => r);
     }
 }
 #endif

--- a/Source/Document Structure/SvgGroup.Drawing.cs
+++ b/Source/Document Structure/SvgGroup.Drawing.cs
@@ -44,7 +44,7 @@ namespace Svg
                         }
                     }
                 }
-                return TransformedBounds(r);
+                return r; // Don't call TransformedBounds because the child elements are already subject to transforms applied on this group
             }
         }
     }

--- a/Source/Document Structure/SvgImage.Drawing.cs
+++ b/Source/Document Structure/SvgImage.Drawing.cs
@@ -15,11 +15,7 @@ namespace Svg
         private bool _gettingBounds;
         private GraphicsPath _path;
 
-        /// <summary>
-        /// Gets the bounds of the element.
-        /// </summary>
-        /// <value>The bounds.</value>
-        public override RectangleF Bounds
+        RectangleF RawBounds
         {
             get
             {
@@ -31,13 +27,18 @@ namespace Svg
                     return new RectangleF();
                 }
                 _gettingBounds = true;
-                var bounds = TransformedBounds(new RectangleF(Location.ToDeviceValue(null, this),
+                var bounds = new RectangleF(Location.ToDeviceValue(null, this),
                     new SizeF(Width.ToDeviceValue(null, UnitRenderingType.Horizontal, this),
-                        Height.ToDeviceValue(null, UnitRenderingType.Vertical, this))));
+                        Height.ToDeviceValue(null, UnitRenderingType.Vertical, this)));
                 _gettingBounds = false;
                 return bounds;
             }
         }
+        /// <inheritdoc/>
+        public override RectangleF Bounds => TransformedBounds(RawBounds);
+        /// <inheritdoc/>
+        public override RectangleF BoundsRelativeToTop => TransformedBoundsPlusParents(RawBounds);
+
 
         /// <summary>
         /// Gets the <see cref="GraphicsPath"/> for this element.

--- a/Source/Document Structure/SvgSwitch.Drawing.cs
+++ b/Source/Document Structure/SvgSwitch.Drawing.cs
@@ -1,4 +1,4 @@
-#if !NO_SDC
+﻿#if !NO_SDC
 using System.Drawing;
 using System.Drawing.Drawing2D;
 
@@ -15,39 +15,10 @@ namespace Svg
             return GetPaths(this, renderer);
         }
 
-        /// <summary>
-        /// Gets the bounds of the element.
-        /// </summary>
-        /// <value>The bounds.</value>
-        public override RectangleF Bounds
-        {
-            get
-            {
-                var r = new RectangleF();
-                foreach (var c in this.Children)
-                {
-                    if (c is SvgVisualElement)
-                    {
-                        // First it should check if rectangle is empty or it will return the wrong Bounds.
-                        // This is because when the Rectangle is Empty, the Union method adds as if the first values where X=0, Y=0
-                        if (r.IsEmpty)
-                        {
-                            r = ((SvgVisualElement)c).Bounds;
-                        }
-                        else
-                        {
-                            var childBounds = ((SvgVisualElement)c).Bounds;
-                            if (!childBounds.IsEmpty)
-                            {
-                                r = RectangleF.Union(r, childBounds);
-                            }
-                        }
-                    }
-                }
-
-                return TransformedBounds(r);
-            }
-        }
+        /// <inheritdoc/>
+        public override RectangleF Bounds => BoundsFromChildren(e => e.Bounds, TransformedBounds);
+        /// <inheritdoc/>
+        public override RectangleF BoundsRelativeToTop => BoundsFromChildren(e => e.BoundsRelativeToTop, r => r);
 
         /// <summary>
         /// Renders the <see cref="SvgElement"/> and contents to the specified <see cref="Graphics"/> object.

--- a/Source/Document Structure/SvgSymbol.Drawing.cs
+++ b/Source/Document Structure/SvgSymbol.Drawing.cs
@@ -15,39 +15,10 @@ namespace Svg
             return GetPaths(this, renderer);
         }
 
-        /// <summary>
-        /// Gets the bounds of the element.
-        /// </summary>
-        /// <value>The bounds.</value>
-        public override RectangleF Bounds
-        {
-            get
-            {
-                var r = new RectangleF();
-                foreach (var c in this.Children)
-                {
-                    if (c is SvgVisualElement)
-                    {
-                        // First it should check if rectangle is empty or it will return the wrong Bounds.
-                        // This is because when the Rectangle is Empty, the Union method adds as if the first values where X=0, Y=0
-                        if (r.IsEmpty)
-                        {
-                            r = ((SvgVisualElement)c).Bounds;
-                        }
-                        else
-                        {
-                            var childBounds = ((SvgVisualElement)c).Bounds;
-                            if (!childBounds.IsEmpty)
-                            {
-                                r = RectangleF.Union(r, childBounds);
-                            }
-                        }
-                    }
-                }
-
-                return TransformedBounds(r);
-            }
-        }
+        /// <inheritdoc/>
+        public override RectangleF Bounds => BoundsFromChildren(e => e.Bounds, TransformedBounds);
+        /// <inheritdoc/>
+        public override RectangleF BoundsRelativeToTop => BoundsFromChildren(e => e.BoundsRelativeToTop, r => r);
 
         /// <summary>
         /// Applies the required transforms to <see cref="ISvgRenderer"/>.

--- a/Source/Extensibility/SvgForeignObject.Drawing.cs
+++ b/Source/Extensibility/SvgForeignObject.Drawing.cs
@@ -1,4 +1,4 @@
-#if !NO_SDC
+﻿#if !NO_SDC
 using System.Drawing;
 using System.Drawing.Drawing2D;
 
@@ -15,39 +15,10 @@ namespace Svg
             return GetPaths(this, renderer);
         }
 
-        /// <summary>
-        /// Gets the bounds of the element.
-        /// </summary>
-        /// <value>The bounds.</value>
-        public override RectangleF Bounds
-        {
-            get
-            {
-                var r = new RectangleF();
-                foreach (var c in this.Children)
-                {
-                    if (c is SvgVisualElement)
-                    {
-                        // First it should check if rectangle is empty or it will return the wrong Bounds.
-                        // This is because when the Rectangle is Empty, the Union method adds as if the first values where X=0, Y=0
-                        if (r.IsEmpty)
-                        {
-                            r = ((SvgVisualElement)c).Bounds;
-                        }
-                        else
-                        {
-                            var childBounds = ((SvgVisualElement)c).Bounds;
-                            if (!childBounds.IsEmpty)
-                            {
-                                r = RectangleF.Union(r, childBounds);
-                            }
-                        }
-                    }
-                }
-
-                return TransformedBounds(r);
-            }
-        }
+        /// <inheritdoc/>
+        public override RectangleF Bounds => BoundsFromChildren(e => e.Bounds, TransformedBounds);
+        /// <inheritdoc/>
+        public override RectangleF BoundsRelativeToTop => BoundsFromChildren(e => e.BoundsRelativeToTop, r => r);
 
         ///// <summary>
         ///// Renders the <see cref="SvgElement"/> and contents to the specified <see cref="Graphics"/> object.

--- a/Source/SvgElement.Drawing.cs
+++ b/Source/SvgElement.Drawing.cs
@@ -79,7 +79,7 @@ namespace Svg
         /// <returns>The transformed rectangle, or the original rectangle if no transformation exists.</returns>
         protected RectangleF TransformedBounds(RectangleF bounds)
         {
-            if (Transforms != null && Transforms.Count > 0)
+            if (Transforms != null && Transforms.Count > 0 && !bounds.IsEmpty)
             {
                 using (var path = new GraphicsPath())
                 using (var matrix = Transforms.GetMatrix())
@@ -90,6 +90,20 @@ namespace Svg
                 }
             }
             return bounds;
+        }
+        protected RectangleF TransformedBoundsFromPathToClone(GraphicsPath path)
+        {
+            if (path is null) return default;
+            if (Transforms != null && Transforms.Count > 0)
+            {
+                using (path = (GraphicsPath)path.Clone())
+                using (var matrix = Transforms.GetMatrix())
+                {
+                    path.Transform(matrix);
+                    return path.GetBounds();
+                }
+            }
+            return path.GetBounds();
         }
 
         /// <summary>

--- a/Source/Text/SvgTextBase.Drawing.cs
+++ b/Source/Text/SvgTextBase.Drawing.cs
@@ -9,11 +9,7 @@ namespace Svg
 {
     public abstract partial class SvgTextBase : SvgVisualElement
     {
-        /// <summary>
-        /// Gets the bounds of the element.
-        /// </summary>
-        /// <value>The bounds.</value>
-        public override RectangleF Bounds
+        GraphicsPath RawPath
         {
             get
             {
@@ -26,17 +22,13 @@ namespace Svg
                         continue;
                     path.AddPath(elem.Path(null), false);
                 }
-                if (Transforms == null || Transforms.Count == 0)
-                    return path.GetBounds();
-
-                using (path = (GraphicsPath)path.Clone())
-                using (var matrix = Transforms.GetMatrix())
-                {
-                    path.Transform(matrix);
-                    return path.GetBounds();
-                }
+                return path;
             }
         }
+        /// <inheritdoc/>
+        public override RectangleF Bounds => TransformedBoundsFromPathToClone(RawPath);
+        /// <inheritdoc/>
+        public override RectangleF BoundsRelativeToTop => TransformedBoundsPlusParentsFromPathToClone(RawPath);
 
         //private static GraphicsPath GetPath(string text, Font font)
         //{


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
There is currently no way to obtain the bounds of an element relative to the whole document instead of relative to the parent. This PR adds that.