### PR TITLE
Converted to HTTPS links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![W3C SVG Logo](https://www.w3.org/Icons/SVG/svg-logo-v.png)
 # SVG.NET[![NuGet version](https://badge.fury.io/nu/svg.svg)](https://badge.fury.io/nu/svg) [![Gitter](https://badges.gitter.im/vvvv/SVG.svg)](https://gitter.im/vvvv/SVG?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) ![Testsuite](https://github.com/svg-net/SVG/workflows/Testsuite/badge.svg?branch=master) ![DocBuild](https://github.com/svg-net/SVG/workflows/DocBuild/badge.svg?branch=master)
 
-Public fork of the C# SVG rendering library on codeplex: https://svg.codeplex.com/
+Public fork of the C# SVG rendering library on codeplex. 
 
 This started out as a minor modification to enable the writing of proper SVG strings. But now after almost two years we have so many fixes and improvements that we decided to share our current codebase to the public in order to improve it even further.
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ This started out as a minor modification to enable the writing of proper SVG str
 So please feel free to fork it and open pull requests for any fix, improvement or feature you add. 
 You may check the [contributing guide](https://github.com/svg-net/SVG/blob/master/CONTRIBUTING.md) for more information on how to do this. 
 
-For information on installation and usage of the library, and for release notes please check the [documentation pages](http://svg-net.github.io/SVG/).
+For information on installation and usage of the library, and for release notes please check the [documentation pages](https://svg-net.github.io/SVG/).
 
 ## Projects using the library
 
-* [vvvv](http://vvvv.org) a hybrid visual/textual live-programming environment for easy prototyping and development.
+* [vvvv](https://vvvv.org) a hybrid visual/textual live-programming environment for easy prototyping and development.
 * [Posh](https://github.com/vvvv/Posh) a windowing/interaction/drawing layer for C#/.NET desktop applications with their GUI in a browser. 
 * [Timeliner](https://github.com/vvvv/Timeliner) a Posh based timeline that can be controlled by and sends out its values via OSC.
-* [Chordious](http://chordious.com) a fretboard diagram generator for fretted stringed instruments.
+* [Chordious](https://chordious.com) a fretboard diagram generator for fretted stringed instruments.
 
 If you want your project in this list, send me a pull request on this file or link + short description to tebjan (at) vvvv.org
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Changed http to http**s** links.

#### Any other comments?
The https://svg.codeplex.com/ link is dead (but it's https already ;)) - maybe remove it? 
