### PR TITLE
Fixed dead link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ This project has dependencies on other open-source projects. These projects are 
 
 |Project|Author|Sources|License|
 |--------|-----|---|---------|
-|Fizzler|Atif Aziz (@atifaziz)|[GitHub](https://github.com/atifaziz/Fizzler)|[LGPL](https://github.com/atifaziz/Fizzler/blob/master/COPYING.LESSER.txt)|
+|Fizzler|Atif Aziz (@atifaziz)|[GitHub](https://github.com/atifaziz/Fizzler)|[LGPL](https://github.com/atifaziz/Fizzler/blob/master/COPYING.txt)|
 |ExCSS|Tyler Brinks (@tylerbrinks)|[GitHub](https://github.com/TylerBrinks/ExCSS)|[MIT](https://github.com/TylerBrinks/ExCSS/blob/master/license.txt)|


### PR DESCRIPTION



#### What does this implement/fix? Explain your changes.
Fixed dead link. As https://github.com/atifaziz/Fizzler/blob/master/COPYING.txt describes LGPL, I assume this is the new correct link


