### PR TITLE
Fixing Text Transformation

### DIFF
--- a/Source/Text/SvgTextBase.cs
+++ b/Source/Text/SvgTextBase.cs
@@ -268,13 +268,13 @@ namespace Svg
             switch (this.TextTransformation)
             {
                 case SvgTextTransformation.Capitalize:
-                    return value.ToUpper();
+                    return CultureInfo.CurrentCulture.TextInfo.ToTitleCase(value);
 
                 case SvgTextTransformation.Uppercase:
                     return value.ToUpper();
 
                 case SvgTextTransformation.Lowercase:
-                    return CultureInfo.CurrentCulture.TextInfo.ToTitleCase(value);
+                    return value.ToLower();
             }
 
             return value;

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -5,6 +5,7 @@ The release versions are NuGet releases.
 
 ### Fixes
 * fixed `text-decoration` conversion (see [#941](https://github.com/svg-net/SVG/issues/941))
+* fixed `text-transformation` (see [#952](https://github.com/svg-net/SVG/issues/952))
 
 ## [Version 3.4.0](https://www.nuget.org/packages/Svg/3.4.0)  (2022-01-09)
 


### PR DESCRIPTION

#### Reference Issue
https://github.com/svg-net/SVG/issues/952

#### What does this implement/fix? Explain your changes.
The Text Transformation feature was not applying the expected transformations

* Lower case : it was applying Capitalize transformation
* Capitalize: it was applying Upper case transformation


#### Any other comments?
I didn't have the chance to add unit test or updating the SvgW3CTestRunner, I didn't find any existing unit test either to update it. I have tested the change and also the issue can be seen clearly