### PR TITLE
* Improve picture clarity

### DIFF
--- a/Source/Rendering/SvgRenderer.cs
+++ b/Source/Rendering/SvgRenderer.cs
@@ -135,6 +135,7 @@ namespace Svg
             g.CompositingQuality = CompositingQuality.HighQuality;
             g.TextRenderingHint = TextRenderingHint.AntiAlias;
             g.TextContrast = 1;
+            g.InterpolationMode = InterpolationMode.NearestNeighbor;
             return g;
         }
 


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

The output image loses a lot of details

source svg:

![source](https://user-images.githubusercontent.com/23184470/177681515-a6acd52a-970f-4fda-b641-0cc80e49ff6f.svg)

before fix (9k):
![after](https://user-images.githubusercontent.com/23184470/177680926-9f41e2ce-cd8b-4977-bad2-53dc2ce62abe.png)

after fix (11k):
![before](https://user-images.githubusercontent.com/23184470/177680905-76f6b67a-639b-4ea8-84fa-db7856d30641.png)


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

https://docs.microsoft.com/en-us/dotnet/api/system.drawing.drawing2d.interpolationmode?view=dotnet-plat-ext-6.0

set  InterpolationMode of  Graphics  as NearestNeighbor
