### PR TITLE
Fix: Out of memory Exception in SvgImage.Render()

### DIFF
--- a/Source/Document Structure/SvgImage.Drawing.cs
+++ b/Source/Document Structure/SvgImage.Drawing.cs
@@ -213,18 +213,17 @@ namespace Svg
                 var httpRequest = WebRequest.Create(uri);
 
                 using (var webResponse = httpRequest.GetResponse())
+                using (var stream = webResponse.GetResponseStream())
                 {
-                    using (var stream = webResponse.GetResponseStream())
-                    {
-                        if (stream.CanSeek)
-                            stream.Position = 0;
+                    if (stream.CanSeek)
+                        stream.Position = 0;
 
-                        if (webResponse.ContentType.StartsWith(MimeTypeSvg, StringComparison.InvariantCultureIgnoreCase) ||
-                            uri.LocalPath.EndsWith(".svg", StringComparison.InvariantCultureIgnoreCase))
-                            return LoadSvg(stream, uri);
-                        else
-                            return Image.FromStream(stream);
-                    }
+                    if (webResponse.ContentType.StartsWith(MimeTypeSvg, StringComparison.InvariantCultureIgnoreCase) ||
+                        uri.LocalPath.EndsWith(".svg", StringComparison.InvariantCultureIgnoreCase))
+                        return LoadSvg(stream, uri);
+                    else
+                        using (var image = Image.FromStream(stream))
+                            return new Bitmap(image);
                 }
             }
             catch (Exception ex)
@@ -288,9 +287,8 @@ namespace Svg
             {
                 var dataBytes = base64 ? Convert.FromBase64String(data) : Encoding.Default.GetBytes(data);
                 using (var stream = new MemoryStream(dataBytes))
-                {
-                    return Image.FromStream(stream);
-                }
+                using (var image = Image.FromStream(stream))
+                    return new Bitmap(image);
             }
             else
                 return null;

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -5,6 +5,7 @@ The release versions are NuGet releases.
 
 ### Fixes
 * fixed localized family names in `SvgFontManager` (see [PR #993](https://github.com/svg-net/SVG/pull/993))
+* fixed out of memory Exception in `SvgImage.Render()` (see [#1003](https://github.com/svg-net/SVG/issues/1003))
 
 ## [Version 3.4.3](https://www.nuget.org/packages/Svg/3.4.3)  (2022-07-16)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Fixes #1003

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

[Image](https://docs.microsoft.com/dotnet/api/system.drawing.image) (and its derived classes) have restrictions on [Stream](https://docs.microsoft.com/dotnet/api/system.io.stream).

> You must keep the stream open for the lifetime of the [Image](https://docs.microsoft.com/dotnet/api/system.drawing.image).

But [Image.Dispose()](https://docs.microsoft.com/dotnet/api/system.drawing.image.dispose) does not [Dispose()](https://docs.microsoft.com/dotnet/api/system.io.stream.dispose) Stream.

[SvgImage](https://github.com/svg-net/SVG/blob/25b3700d88f7d39d146483cd00fb8eb4b582e5c7/Source/Document%20Structure/SvgImage.Drawing.cs#L13) publishes [GetImage()](https://github.com/svg-net/SVG/blob/25b3700d88f7d39d146483cd00fb8eb4b582e5c7/Source/Document%20Structure/SvgImage.Drawing.cs#L184), so [SvgImage](https://github.com/svg-net/SVG/blob/25b3700d88f7d39d146483cd00fb8eb4b582e5c7/Source/Document%20Structure/SvgImage.Drawing.cs#L13) cannot manage [Dispose()](https://docs.microsoft.com/dotnet/api/system.io.stream.dispose) of Stream.

Image can be duplicated by the following two methods.
`Method 2` was adopted because it was not possible to close the Stream with `Method 1` by experiment.

1. [Clone()](https://docs.microsoft.com/dotnet/api/system.drawing.image.clone)
2. [Bitmap(Image)](https://docs.microsoft.com/dotnet/api/system.drawing.bitmap.-ctor#system-drawing-bitmap-ctor(system-drawing-image))

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
