### PR TITLE
Added net6.0-windows to TFMs.

### DIFF
--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0-windows;net462</TargetFrameworks>
     <PackageLicenseExpression>MS-PL</PackageLicenseExpression>
     <RootNamespace>Svg</RootNamespace>
     <AssemblyName>Svg</AssemblyName>
@@ -57,39 +57,44 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net452'">
-    <Title>Svg for .Net Framework 4.5.2</Title>
+    <Title>Svg for .NET Framework 4.5.2</Title>
     <DefineConstants>$(DefineConstants);NETFULL;NET452;Net4</DefineConstants>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net462'">
-    <Title>Svg for .Net Framework 4.6.2</Title>
+    <Title>Svg for .NET Framework 4.6.2</Title>
     <DefineConstants>$(DefineConstants);NETFULL;NET462;Net4</DefineConstants>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
-    <Title>Svg for .Net Core 2.1</Title>
+    <Title>Svg for .NET Core 2.1</Title>
     <DefineConstants>$(DefineConstants);NETCORE;NETCORE21</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
-    <Title>Svg for .Net Core 3.1</Title>
+    <Title>Svg for .NET Core 3.1</Title>
     <DefineConstants>$(DefineConstants);NETCORE;NETCORE31</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net5.0'">
-    <Title>Svg for .Net 5.0</Title>
+    <Title>Svg for .NET 5.0</Title>
     <DefineConstants>$(DefineConstants);NETCORE;NETCORE50</DefineConstants>
+  </PropertyGroup>
+   
+  <PropertyGroup Condition="'$(TargetFramework)'=='net6.0-windows'">
+    <Title>Svg for .NET 6.0 on WindowsDesktop (WinForms, WPF)</Title>
+    <DefineConstants>$(DefineConstants);NETCORE;NETCORE60</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-    <Title>Svg for .Net Standard 2.0</Title>
+    <Title>Svg for .NET Standard 2.0</Title>
     <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD20</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.1'">
-    <Title>Svg for .Net Standard 2.1</Title>
+    <Title>Svg for .NET Standard 2.1</Title>
     <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD21</DefineConstants>
   </PropertyGroup>
 
@@ -106,6 +111,7 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
+  <!-- In .NET 6 these 2 packages are not required. -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
     <PackageReference Include="System.ObjectModel" Version="4.3.0" />
@@ -117,7 +123,7 @@
   </ItemGroup>
 
   <!-- Mac specific include -->
-
+  <!-- Not required for net6.0-windows as that is only meant to be used on windows. -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.8.64" />
   </ItemGroup>
@@ -127,7 +133,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.4" Condition="'$(TargetFramework)' != 'net6.0-windows'" />
     <PackageReference Include="ExCSS" Version="4.1.4" />
     <PackageReference Include="Fizzler" Version="1.2.1" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37">

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0-windows;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net462</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net6.0-windows</TargetFrameworks>
     <PackageLicenseExpression>MS-PL</PackageLicenseExpression>
     <RootNamespace>Svg</RootNamespace>
     <AssemblyName>Svg</AssemblyName>


### PR DESCRIPTION
Due to the fact that in .NET 6 S.D.C is Windows only, I decided to make a Windows only target for .NET 6 which removes a few annoying package refs that get placed into my build outputs in my .NET 6 WinForms applications that use Svg. If the application is windows only, I see no need to include the ``osx`` System.Drawing runtime reference either.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Contributes to: https://github.com/svg-net/SVG/issues/939


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->
This adds a ``net6.0-windows`` target to Svg which allows it to be used in .NET 6 WindowsDesktop applications without annoyingly unneeded dependencies polluting the output directory in them.

#### Any other comments?
<!--
-->
None.

<!--
Thanks for contributing!
-->
