### PR TITLE
Update System.Drawing.Common to fix CVE-2021-26701

### DIFF
--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -107,12 +107,12 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.3" />
     <PackageReference Include="System.ObjectModel" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.3" />
     <PackageReference Include="System.ObjectModel" Version="4.3.0" />
   </ItemGroup>
 

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -7,6 +7,7 @@ The release versions are NuGet releases.
 * fixed localized family names in `SvgFontManager` (see [PR #993](https://github.com/svg-net/SVG/pull/993))
 * fixed out of memory Exception in `SvgImage.Render()` (see [#1003](https://github.com/svg-net/SVG/issues/1003))
 * fixed argument Exception in `Draw(Graphics)` (see [#1004](https://github.com/svg-net/SVG/issues/1004))
+ * updated System.Drawing.Common to prevent Remote Code Execution Vulnerability (see [#1025](https://github.com/svg-net/SVG/issues/1025))
 
 ### Performance
 * performance optimization for `SvgPath.Path()` (see [#1018](https://github.com/svg-net/SVG/issues/1018), [#1013](https://github.com/svg-net/SVG/issues/1013))


### PR DESCRIPTION
System.Drawing.Common 5.0.0 has a .NET Core Remote Code Execution Vulnerability.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
#1025 

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->
 This pull request updates its version to 5.0.3
#### Any other comments?
<!--
-->
More on the vulnerability here: https://msrc.microsoft.com/update-guide/en-US/vulnerability/CVE-2021-26701
<!--
Thanks for contributing!
-->
