### PR TITLE
Fix: Compile error in latest C#.

### DIFF
--- a/Source/Paths/CoordinateParser.cs
+++ b/Source/Paths/CoordinateParser.cs
@@ -24,7 +24,7 @@ namespace Svg
         public int Position;
         public bool HasMore;
 
-        public CoordinateParserState(scoped ref ReadOnlySpan<char> chars)
+        public CoordinateParserState(ref ReadOnlySpan<char> chars)
         {
             CurrNumState = NumState.Separator;
             NewNumState = NumState.Separator;

--- a/Source/Paths/CoordinateParser.cs
+++ b/Source/Paths/CoordinateParser.cs
@@ -24,7 +24,7 @@ namespace Svg
         public int Position;
         public bool HasMore;
 
-        public CoordinateParserState(ref ReadOnlySpan<char> chars)
+        public CoordinateParserState(scoped ref ReadOnlySpan<char> chars)
         {
             CurrNumState = NumState.Separator;
             NewNumState = NumState.Separator;

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -33,7 +33,7 @@
     <PackageProjectUrl>https://github.com/svg-net/SVG</PackageProjectUrl>
     <PackageIconUrl>https://www.w3.org/Icons/SVG/svg-logo-v.png</PackageIconUrl>
     <PackageIcon>svg-logo-v.png</PackageIcon>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -3,6 +3,9 @@ The release versions are NuGet releases.
 
 ## Unreleased
 
+### Fixes
+* fixed build error in C# 11 (see [PR #1030](https://github.com/svg-net/SVG/pull/1030))
+
 ## [Version 3.4.4](https://www.nuget.org/packages/Svg/3.4.4)  (2022-10-29)
 
 ### Fixes


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Ref. [Instance method on ref struct may capture unscoped ref parameters](https://learn.microsoft.com/dotnet/csharp/whats-new/breaking-changes/compiler%20breaking%20changes%20-%20dotnet%207#instance-method-on-ref-struct-may-capture-unscoped-ref-parameters)

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
