### PR TITLE
Fix OutOfMemory exception on SVGs with gradients

### DIFF
--- a/Source/Painting/SvgLinearGradientServer.Drawing.cs
+++ b/Source/Painting/SvgLinearGradientServer.Drawing.cs
@@ -147,6 +147,29 @@ namespace Svg
             return new GradientPoints(effectiveStart, effectiveEnd);
         }
 
+        class MyPointFEqualityComparer : EqualityComparer<PointF>
+        {
+            public override bool Equals(PointF pt1, PointF pt2)
+            {
+                if (pt2 == null && pt1 == null)
+                    return true;
+                else if (pt1 == null || pt2 == null)
+                    return false;
+                else if (pt1.X == pt2.X && pt2.Y == pt2.Y)
+                    return true;
+                else if (Math.Round(pt1.X) == Math.Round(pt2.X) && Math.Round(pt2.Y) == Math.Round(pt2.Y))
+                    return true;
+                else
+                    return false;
+            }
+
+            public override int GetHashCode(PointF pt)
+            {
+                int hCode = (int)pt.X ^ (int)pt.Y;
+                return hCode.GetHashCode();
+            }
+        }
+
         private IList<PointF> CandidateIntersections(RectangleF bounds, PointF p1, PointF p2)
         {
             var results = new List<PointF>();
@@ -171,9 +194,11 @@ namespace Svg
                 else
                 {
                     candidate = new PointF(bounds.Left, (p2.Y - p1.Y) / (p2.X - p1.X) * (bounds.Left - p1.X) + p1.Y);
-                    if (bounds.Top <= candidate.Y && candidate.Y <= bounds.Bottom) results.Add(candidate);
+                    if (bounds.Top <= candidate.Y && candidate.Y <= bounds.Bottom && !results.Contains(candidate, new MyPointFEqualityComparer()))
+                        results.Add(candidate);
                     candidate = new PointF(bounds.Right, (p2.Y - p1.Y) / (p2.X - p1.X) * (bounds.Right - p1.X) + p1.Y);
-                    if (bounds.Top <= candidate.Y && candidate.Y <= bounds.Bottom) results.Add(candidate);
+                    if (bounds.Top <= candidate.Y && candidate.Y <= bounds.Bottom && !results.Contains(candidate, new MyPointFEqualityComparer()))
+                        results.Add(candidate);
                 }
                 if ((p2.X == bounds.Left || p2.X == bounds.Right) && (p2.Y == bounds.Top || p2.Y == bounds.Bottom))
                 {
@@ -182,9 +207,11 @@ namespace Svg
                 else
                 {
                     candidate = new PointF((bounds.Top - p1.Y) / (p2.Y - p1.Y) * (p2.X - p1.X) + p1.X, bounds.Top);
-                    if (bounds.Left <= candidate.X && candidate.X <= bounds.Right) results.Add(candidate);
+                    if (bounds.Left <= candidate.X && candidate.X <= bounds.Right && !results.Contains(candidate, new MyPointFEqualityComparer()))
+                        results.Add(candidate);
                     candidate = new PointF((bounds.Bottom - p1.Y) / (p2.Y - p1.Y) * (p2.X - p1.X) + p1.X, bounds.Bottom);
-                    if (bounds.Left <= candidate.X && candidate.X <= bounds.Right) results.Add(candidate);
+                    if (bounds.Left <= candidate.X && candidate.X <= bounds.Right && !results.Contains(candidate, new MyPointFEqualityComparer()))
+                        results.Add(candidate);
                 }
             }
 


### PR DESCRIPTION
Source: the8thavatar, https://github.com/svg-net/SVG/issues/1008#issue-1370121240

#### Reference Issue
Fixes #95 


#### What does this implement/fix? Explain your changes.
This fixes an OutOfMemory exception on SVGs with gradients that are very small/near by ignoring small differences using an EqualityComparer.