### PR TITLE
Update Nerdbank.GitVersioning from version 3.3.37 to 3.5.119

### DIFF
--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -130,7 +130,7 @@
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="ExCSS" Version="4.1.4" />
     <PackageReference Include="Fizzler" Version="1.2.1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.119">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Currently, the project is not compilable with Visual Studio. In order to fix this, Nerdbank.GitVersioning needed to be updated from version 3.3.37 to 3.5.119.

#### Any other comments?
Additionally, I had to remove these lines in Samples\SvgConsole\SvgConsole.csproj:
```
    <IsTool>True</IsTool>
    <PackAsTool>True</PackAsTool>
```
I didn't commit this, but I would consider removing them to make it easier for the other devs (or add this info to CONTRIBUTING.md or README.md).