### PR TITLE
Update .NET Framework from version 4.6.2 to 4.8

### DIFF
--- a/Samples/Entities/Entities.csproj
+++ b/Samples/Entities/Entities.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/SVGBuilder/SVGBuilder.csproj
+++ b/Samples/SVGBuilder/SVGBuilder.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net462;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>

--- a/Samples/SVGViewer/SVGViewer.csproj
+++ b/Samples/SVGViewer/SVGViewer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net462;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>

--- a/Samples/SvgRuntimeUpdates/SvgRuntimeUpdates.csproj
+++ b/Samples/SvgRuntimeUpdates/SvgRuntimeUpdates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net48</TargetFrameworks>
     <PackageLicenseExpression>MS-PL</PackageLicenseExpression>
     <RootNamespace>Svg</RootNamespace>
     <AssemblyName>Svg</AssemblyName>

--- a/Tests/Svg.Benchmark/Svg.Benchmark.csproj
+++ b/Tests/Svg.Benchmark/Svg.Benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net462</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>

--- a/Tests/Svg.UnitTests/Svg.UnitTests.csproj
+++ b/Tests/Svg.UnitTests/Svg.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net462</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>svgkey.snk</AssemblyOriginatorKeyFile>

--- a/Tests/SvgW3CTestRunner/SvgW3CTestRunner.csproj
+++ b/Tests/SvgW3CTestRunner/SvgW3CTestRunner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;netcoreapp3.1;net5.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This commit updates .NET Framework from version 4.6.2 to 4.8.

#### Any other comments?
If there is a specific reason to stay on 4.6.2, feel free to discard this pull request. It compiles and works just fine (I tested the DLL).