### PR TITLE
Fix OutOfMemory exception on SVGs with gradients

### DIFF
--- a/Source/Painting/SvgLinearGradientServer.Drawing.cs
+++ b/Source/Painting/SvgLinearGradientServer.Drawing.cs
@@ -147,6 +147,29 @@ namespace Svg
             return new GradientPoints(effectiveStart, effectiveEnd);
         }
 
+        class MyPointFEqualityComparer : EqualityComparer<PointF>
+        {
+            public override bool Equals(PointF pt1, PointF pt2)
+            {
+                if (pt2 == null && pt1 == null)
+                    return true;
+                else if (pt1 == null || pt2 == null)
+                    return false;
+                else if (pt1.X == pt2.X && pt2.Y == pt2.Y)
+                    return true;
+                else if (Math.Round(pt1.X) == Math.Round(pt2.X) && Math.Round(pt2.Y) == Math.Round(pt2.Y))
+                    return true;
+                else
+                    return false;
+            }
+
+            public override int GetHashCode(PointF pt)
+            {
+                int hCode = (int)pt.X ^ (int)pt.Y;
+                return hCode.GetHashCode();
+            }
+        }
+
         private IList<PointF> CandidateIntersections(RectangleF bounds, PointF p1, PointF p2)
         {
             var results = new List<PointF>();
@@ -171,9 +194,11 @@ namespace Svg
                 else
                 {
                     candidate = new PointF(bounds.Left, (p2.Y - p1.Y) / (p2.X - p1.X) * (bounds.Left - p1.X) + p1.Y);
-                    if (bounds.Top <= candidate.Y && candidate.Y <= bounds.Bottom) results.Add(candidate);
+                    if (bounds.Top <= candidate.Y && candidate.Y <= bounds.Bottom && !results.Contains(candidate, new MyPointFEqualityComparer()))
+                        results.Add(candidate);
                     candidate = new PointF(bounds.Right, (p2.Y - p1.Y) / (p2.X - p1.X) * (bounds.Right - p1.X) + p1.Y);
-                    if (bounds.Top <= candidate.Y && candidate.Y <= bounds.Bottom) results.Add(candidate);
+                    if (bounds.Top <= candidate.Y && candidate.Y <= bounds.Bottom && !results.Contains(candidate, new MyPointFEqualityComparer()))
+                        results.Add(candidate);
                 }
                 if ((p2.X == bounds.Left || p2.X == bounds.Right) && (p2.Y == bounds.Top || p2.Y == bounds.Bottom))
                 {
@@ -182,9 +207,11 @@ namespace Svg
                 else
                 {
                     candidate = new PointF((bounds.Top - p1.Y) / (p2.Y - p1.Y) * (p2.X - p1.X) + p1.X, bounds.Top);
-                    if (bounds.Left <= candidate.X && candidate.X <= bounds.Right) results.Add(candidate);
+                    if (bounds.Left <= candidate.X && candidate.X <= bounds.Right && !results.Contains(candidate, new MyPointFEqualityComparer()))
+                        results.Add(candidate);
                     candidate = new PointF((bounds.Bottom - p1.Y) / (p2.Y - p1.Y) * (p2.X - p1.X) + p1.X, bounds.Bottom);
-                    if (bounds.Left <= candidate.X && candidate.X <= bounds.Right) results.Add(candidate);
+                    if (bounds.Left <= candidate.X && candidate.X <= bounds.Right && !results.Contains(candidate, new MyPointFEqualityComparer()))
+                        results.Add(candidate);
                 }
             }
 

--- a/Source/Painting/SvgLinearGradientServer.Drawing.cs
+++ b/Source/Painting/SvgLinearGradientServer.Drawing.cs
@@ -201,10 +201,10 @@ namespace Svg
                 else
                 {
                     candidate = new PointF(bounds.Left, (p2.Y - p1.Y) / (p2.X - p1.X) * (bounds.Left - p1.X) + p1.Y);
-                    if (bounds.Top <= candidate.Y && candidate.Y <= bounds.Bottom && !results.Contains(candidate, new MyPointFEqualityComparer()))
+                    if (bounds.Top <= candidate.Y && candidate.Y <= bounds.Bottom && !results.Contains(candidate, new PointFEqualityComparer()))
                         results.Add(candidate);
                     candidate = new PointF(bounds.Right, (p2.Y - p1.Y) / (p2.X - p1.X) * (bounds.Right - p1.X) + p1.Y);
-                    if (bounds.Top <= candidate.Y && candidate.Y <= bounds.Bottom && !results.Contains(candidate, new MyPointFEqualityComparer()))
+                    if (bounds.Top <= candidate.Y && candidate.Y <= bounds.Bottom && !results.Contains(candidate, new PointFEqualityComparer()))
                         results.Add(candidate);
                 }
                 if ((p2.X == bounds.Left || p2.X == bounds.Right) && (p2.Y == bounds.Top || p2.Y == bounds.Bottom))
@@ -214,10 +214,10 @@ namespace Svg
                 else
                 {
                     candidate = new PointF((bounds.Top - p1.Y) / (p2.Y - p1.Y) * (p2.X - p1.X) + p1.X, bounds.Top);
-                    if (bounds.Left <= candidate.X && candidate.X <= bounds.Right && !results.Contains(candidate, new MyPointFEqualityComparer()))
+                    if (bounds.Left <= candidate.X && candidate.X <= bounds.Right && !results.Contains(candidate, new PointFEqualityComparer()))
                         results.Add(candidate);
                     candidate = new PointF((bounds.Bottom - p1.Y) / (p2.Y - p1.Y) * (p2.X - p1.X) + p1.X, bounds.Bottom);
-                    if (bounds.Left <= candidate.X && candidate.X <= bounds.Right && !results.Contains(candidate, new MyPointFEqualityComparer()))
+                    if (bounds.Left <= candidate.X && candidate.X <= bounds.Right && !results.Contains(candidate, new PointFEqualityComparer()))
                         results.Add(candidate);
                 }
             }

--- a/Source/Painting/SvgLinearGradientServer.Drawing.cs
+++ b/Source/Painting/SvgLinearGradientServer.Drawing.cs
@@ -120,7 +120,6 @@ namespace Svg
 
             if (intersectionPoints.Count < 2)
             {
-                Console.WriteLine("Unanticipated number of intersection points!");
                 return new GradientPoints(specifiedStart, specifiedEnd);
             }
 

--- a/Source/Painting/SvgLinearGradientServer.Drawing.cs
+++ b/Source/Painting/SvgLinearGradientServer.Drawing.cs
@@ -118,7 +118,11 @@ namespace Svg
             var effectiveEnd = specifiedEnd;
             var intersectionPoints = CandidateIntersections(bounds, specifiedStart, specifiedEnd);
 
-            Debug.Assert(intersectionPoints.Count == 2, "Unanticipated number of intersection points");
+            if (intersectionPoints.Count < 2)
+            {
+                Console.WriteLine("Unanticipated number of intersection points!");
+                return new GradientPoints(specifiedStart, specifiedEnd);
+            }
 
             if (!(Math.Sign(intersectionPoints[1].X - intersectionPoints[0].X) == Math.Sign(specifiedEnd.X - specifiedStart.X) &&
                   Math.Sign(intersectionPoints[1].Y - intersectionPoints[0].Y) == Math.Sign(specifiedEnd.Y - specifiedStart.Y)))
@@ -147,20 +151,23 @@ namespace Svg
             return new GradientPoints(effectiveStart, effectiveEnd);
         }
 
-        class MyPointFEqualityComparer : EqualityComparer<PointF>
+        class PointFEqualityComparer : EqualityComparer<PointF>
         {
             public override bool Equals(PointF pt1, PointF pt2)
             {
                 if (pt2 == null && pt1 == null)
                     return true;
-                else if (pt1 == null || pt2 == null)
+
+                if (pt1 == null || pt2 == null)
                     return false;
-                else if (pt1.X == pt2.X && pt2.Y == pt2.Y)
+
+                if (pt1.X == pt2.X && pt2.Y == pt2.Y)
                     return true;
-                else if (Math.Round(pt1.X) == Math.Round(pt2.X) && Math.Round(pt2.Y) == Math.Round(pt2.Y))
+
+                if (Math.Round(pt1.X) == Math.Round(pt2.X) && Math.Round(pt2.Y) == Math.Round(pt2.Y))
                     return true;
-                else
-                    return false;
+
+                return false;
             }
 
             public override int GetHashCode(PointF pt)

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -5,6 +5,7 @@ The release versions are NuGet releases.
 
 ### Fixes
 * fixed build error in C# 11 (see [PR #1030](https://github.com/svg-net/SVG/pull/1030))
+* fixed out of memory exception on SVGs with gradients (see [PR #1038] (https://github.com/svg-net/SVG/pull/1038))
 
 ## [Version 3.4.4](https://www.nuget.org/packages/Svg/3.4.4)  (2022-10-29)
 


### PR DESCRIPTION
Source: the8thavatar, https://github.com/svg-net/SVG/issues/1008#issue-1370121240

#### Reference Issue
Fixes #95 


#### What does this implement/fix? Explain your changes.
This fixes an OutOfMemory exception on SVGs with gradients that are very small/near by ignoring small differences using an EqualityComparer.

This is an addendum to https://github.com/svg-net/SVG/pull/1035. Please close the other one.