### PR TITLE
Fix Assembly in Generated API documentation.

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -3,8 +3,8 @@
     {
       "src": [
         {
-          "files": [ "**/*.cs" ],
-          "exclude": [ "**/bin/**", "**/obj/**", "External/**" ],
+          "files": [ "**/*.csproj" ],
+          "exclude": [ "**/bin/**", "**/obj/**" ],
           "src": "Source"
         }
       ],


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

`Generated API documentation` is below.

`Assembly: cs.temp.dll.dll`

It seems that specifying project file resolves assembly name.

`Assembly: Svg.dll`

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
