### PR TITLE
Fix `DeepCopy` result miss the `_styles` issue

### DIFF
--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -1044,6 +1044,10 @@ namespace Svg
             foreach (var node in Nodes)
                 newObj.Nodes.Add(node.DeepCopy());
 
+            foreach (var style in _styles)
+            foreach (var pair in style.Value)
+                newObj.AddStyle(style.Key, pair.Value, pair.Key);
+
             return newObj;
         }
 

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -9,6 +9,7 @@ The release versions are NuGet releases.
 ### Fixes
 * fixed build error in C# 11 (see [PR #1030](https://github.com/svg-net/SVG/pull/1030))
 * fixed out of memory exception on SVGs with gradients (see [PR #1038] (https://github.com/svg-net/SVG/pull/1038))
+* fixed missing styles when `DeepCopy` the `SvgElement` (see [PR #1053] (https://github.com/svg-net/SVG/pull/1053))
 
 ## [Version 3.4.4](https://www.nuget.org/packages/Svg/3.4.4)  (2022-10-29)
 


### PR DESCRIPTION
Some svg elements have styles that may include `clip-path`, the `DeepCopy` method should handle the `_styles`