### PR TITLE
Fix the color string format incompatible with the Edge/Chrome in case of no `System.Drawing.Common`

### DIFF
--- a/Source/Painting/SvgColourConverter.cs
+++ b/Source/Painting/SvgColourConverter.cs
@@ -204,7 +204,30 @@ namespace Svg
 #endif
             }
 
-            return base.ConvertTo(context, culture, value, destinationType);
+            return ToHtml((Color)value);
+        }
+
+        /// <summary>
+        /// Converts color to html string format.
+        /// Refer to https://source.dot.net/#System.Drawing.Primitives/System/Drawing/ColorTranslator.cs
+        /// </summary>
+        /// <param name="c"></param>
+        /// <returns></returns>
+        private static string ToHtml(Color c)
+        {
+            var colorString = string.Empty;
+            if (c.IsEmpty)
+                return colorString;
+
+            if (c.IsNamedColor)
+            {
+                colorString = c == Color.LightGray ? "LightGrey" : c.Name;
+                colorString = colorString.ToLowerInvariant();
+            }
+            else
+                colorString = $"#{c.R:X2}{c.G:X2}{c.B:X2}";
+
+            return colorString;
         }
 
         /// <summary>

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -8,8 +8,9 @@ The release versions are NuGet releases.
 
 ### Fixes
 * fixed build error in C# 11 (see [PR #1030](https://github.com/svg-net/SVG/pull/1030))
-* fixed out of memory exception on SVGs with gradients (see [PR #1038] (https://github.com/svg-net/SVG/pull/1038))
-* fixed missing styles when `DeepCopy` the `SvgElement` (see [PR #1053] (https://github.com/svg-net/SVG/pull/1053))
+* fixed out of memory exception on SVGs with gradients (see [PR #1038](https://github.com/svg-net/SVG/pull/1038))
+* fixed missing styles when `DeepCopy` the `SvgElement` (see [PR #1053](https://github.com/svg-net/SVG/pull/1053))
+* fix the color string format incompatible with the Edge/Chrome browsers in case of no System.Drawing.Common (see [PR #1055](https://github.com/svg-net/SVG/pull/1055))
 
 ## [Version 3.4.4](https://www.nuget.org/packages/Svg/3.4.4)  (2022-10-29)
 


### PR DESCRIPTION
Fix the color string format incompatible with the Edge/Chrome in case of no `System.Drawing.Common`

In case of no `System.Drawing.Common`, the `SvgColourConverter.ConvertTo` method returns `'Red'`(with extra quotation mark), or `255, 17, 0` this lead to the resaved svg file can not display correctly by the Edge/Chrome, and this is not fit the svg w3c standard

So here introduce `SvgColourConverter.ToHtml` to handle it
