### PR TITLE
Fix: duplication of excessive SvgElement in DeepCopy

### DIFF
--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -1045,8 +1045,8 @@ namespace Svg
                 newObj.Nodes.Add(node.DeepCopy());
 
             foreach (var style in _styles)
-            foreach (var pair in style.Value)
-                newObj.AddStyle(style.Key, pair.Value, pair.Key);
+                foreach (var pair in style.Value)
+                    newObj.AddStyle(style.Key, pair.Value, pair.Key);
 
             return newObj;
         }

--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -1042,7 +1042,18 @@ namespace Svg
                 newObj.CustomAttributes.Add(attribute.Key, attribute.Value);
 
             foreach (var node in Nodes)
-                newObj.Nodes.Add(node is SvgElement ? newObj.Children[Children.IndexOf((SvgElement)node)] : node.DeepCopy());
+            {
+                if (node is SvgElement)
+                {
+                    var index = Children.IndexOf((SvgElement)node);
+                    if (index >= 0)
+                    {
+                        newObj.Nodes.Add(newObj.Children[index]);
+                        continue;
+                    }
+                }
+                newObj.Nodes.Add(node.DeepCopy());
+            }
 
             foreach (var style in _styles)
                 foreach (var pair in style.Value)

--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -1042,7 +1042,7 @@ namespace Svg
                 newObj.CustomAttributes.Add(attribute.Key, attribute.Value);
 
             foreach (var node in Nodes)
-                newObj.Nodes.Add(node.DeepCopy());
+                newObj.Nodes.Add(node is SvgElement ? newObj.Children[Children.IndexOf((SvgElement)node)] : node.DeepCopy());
 
             foreach (var style in _styles)
                 foreach (var pair in style.Value)

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -11,6 +11,7 @@ The release versions are NuGet releases.
 * fixed out of memory exception on SVGs with gradients (see [PR #1038](https://github.com/svg-net/SVG/pull/1038))
 * fixed missing styles when `DeepCopy` the `SvgElement` (see [PR #1053](https://github.com/svg-net/SVG/pull/1053))
 * fix the color string format incompatible with the Edge/Chrome browsers in case of no System.Drawing.Common (see [PR #1055](https://github.com/svg-net/SVG/pull/1055))
+* fixed duplication of excessive `SvgElement`s in `DeepCopy` (see [#1054](https://github.com/svg-net/SVG/issues/1054))
 
 ## [Version 3.4.4](https://www.nuget.org/packages/Svg/3.4.4)  (2022-10-29)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Fixes #1054

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
