### PR TITLE
Reduce pressure on SOH in hot path

### DIFF
--- a/Source/Paths/SvgPathBuilder.cs
+++ b/Source/Paths/SvgPathBuilder.cs
@@ -17,7 +17,7 @@ namespace Svg
 
         public static string ToSvgString(this PointF p)
         {
-            return p.X.ToSvgString() + " " + p.Y.ToSvgString();
+            return $"{p.X.ToSvgString()} {p.Y.ToSvgString()}";
         }
     }
 


### PR DESCRIPTION
This line is on a hot path and string interopolation reduces the number of memory allocations for strings.