### PR TITLE
Gratuitous byte[] allocations

### DIFF
--- a/Source/Paths/SvgClosePathSegment.Drawing.cs
+++ b/Source/Paths/SvgClosePathSegment.Drawing.cs
@@ -1,4 +1,4 @@
-#if !NO_SDC
+﻿#if !NO_SDC
 using System.Drawing;
 using System.Drawing.Drawing2D;
 
@@ -11,8 +11,9 @@ namespace Svg.Pathing
             graphicsPath.CloseFigure();
 
             var end = start;
+            var pathTypes = graphicsPath.PathTypes;
             for (var i = graphicsPath.PointCount - 1; i >= 0; --i)
-                if ((graphicsPath.PathTypes[i] & 0x7) == 0)
+                if ((pathTypes[i] & 0x7) == 0)
                 {
                     end = graphicsPath.PathPoints[i];
                     break;

--- a/Source/Paths/SvgClosePathSegment.Drawing.cs
+++ b/Source/Paths/SvgClosePathSegment.Drawing.cs
@@ -1,4 +1,4 @@
-﻿#if !NO_SDC
+#if !NO_SDC
 using System.Drawing;
 using System.Drawing.Drawing2D;
 
@@ -11,10 +11,8 @@ namespace Svg.Pathing
             graphicsPath.CloseFigure();
 
             var end = start;
-            var pathTypes = graphicsPath.PathTypes;
-            
             for (var i = graphicsPath.PointCount - 1; i >= 0; --i)
-                if ((pathTypes[i] & 0x7) == 0)
+                if ((graphicsPath.PathTypes[i] & 0x7) == 0)
                 {
                     end = graphicsPath.PathPoints[i];
                     break;

--- a/Source/Paths/SvgClosePathSegment.Drawing.cs
+++ b/Source/Paths/SvgClosePathSegment.Drawing.cs
@@ -1,4 +1,4 @@
-#if !NO_SDC
+﻿#if !NO_SDC
 using System.Drawing;
 using System.Drawing.Drawing2D;
 
@@ -11,8 +11,10 @@ namespace Svg.Pathing
             graphicsPath.CloseFigure();
 
             var end = start;
+            var pathTypes = graphicsPath.PathTypes;
+            
             for (var i = graphicsPath.PointCount - 1; i >= 0; --i)
-                if ((graphicsPath.PathTypes[i] & 0x7) == 0)
+                if ((pathTypes[i] & 0x7) == 0)
                 {
                     end = graphicsPath.PathPoints[i];
                     break;


### PR DESCRIPTION
graphicsPath.PathTypes[i] allocates a byte array in a loop. Taken outside of the loop to significantly reduce SOH allocations and noticeably improve performance with large SVG files.