### PR TITLE
Update ex css to 4.2.1 (In preparation for using it to evaluate css selector)

### DIFF
--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -87,7 +87,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ExCSS" Version="4.1.4" />
+    <PackageReference Include="ExCSS" Version="4.2.1" />
     <PackageReference Include="Fizzler" Version="1.2.1" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37">
       <PrivateAssets>all</PrivateAssets>

--- a/Source/SvgDocument.cs
+++ b/Source/SvgDocument.cs
@@ -444,7 +444,7 @@ namespace Svg
             if (styles.Any())
             {
                 var cssTotal = string.Join(Environment.NewLine, styles.Select(s => s.Content).ToArray());
-                var stylesheetParser = new StylesheetParser(true, true);
+                var stylesheetParser = new StylesheetParser(true, true, tolerateInvalidValues: true);
                 var stylesheet = stylesheetParser.Parse(cssTotal);
 
                 foreach (var rule in stylesheet.StyleRules)

--- a/Source/SvgElementFactory.cs
+++ b/Source/SvgElementFactory.cs
@@ -52,7 +52,7 @@ namespace Svg
         private static readonly Dictionary<string, ElementInfo> availableElementsWithoutSvg;
         private static readonly List<ElementInfo> availableElements;
 #endif
-        private readonly StylesheetParser stylesheetParser = new StylesheetParser(true, true);
+        private readonly StylesheetParser stylesheetParser = new StylesheetParser(true, true, tolerateInvalidValues: true);
 
         /// <summary>
         /// Gets a list of available types that can be used when creating an <see cref="SvgElement"/>.

--- a/Tests/Svg.UnitTests/EntitiesTests.cs
+++ b/Tests/Svg.UnitTests/EntitiesTests.cs
@@ -26,8 +26,8 @@ namespace Svg.UnitTests
 
             var svgPath = Path.Combine(TestsRootPath, EntitiesSampleSvgPath);
             var doc = SvgDocument.Open<SvgDocument>(svgPath, entities);
-            Assert.That(doc.Children[0].Children[0].Fill, Is.EqualTo(new SvgColourServer(Color.Red)));
-            Assert.That(doc.Children[0].Children[1].Fill, Is.EqualTo(new SvgColourServer(Color.Yellow)));
+            Assert.That(doc.Children[0].Children[0].Fill, Is.EqualTo(new SvgColourServer(Color.FromArgb(255, 0 ,0))));
+            Assert.That(doc.Children[0].Children[1].Fill, Is.EqualTo(new SvgColourServer(Color.FromArgb(255, 255 ,0))));
         }
 
         [Test]

--- a/Tests/Svg.UnitTests/LexerIssueTests.cs
+++ b/Tests/Svg.UnitTests/LexerIssueTests.cs
@@ -55,8 +55,8 @@ namespace Svg.UnitTests
             // valid colors
             var doc = GenerateLexerTestFile("fill: #ff0000; stroke: #ffff00");
             var path = doc.GetElementById<SvgPath>("path1");
-            Assert.AreEqual(System.Drawing.Color.Red, ((SvgColourServer)path.Fill).Colour);
-            Assert.AreEqual(System.Drawing.Color.Yellow, ((SvgColourServer)path.Stroke).Colour);
+            Assert.AreEqual(System.Drawing.Color.FromArgb(255,0,0), ((SvgColourServer)path.Fill).Colour);
+            Assert.AreEqual(System.Drawing.Color.FromArgb(255,255, 0), ((SvgColourServer)path.Stroke).Colour);
         }
 
         [Test]
@@ -66,8 +66,8 @@ namespace Svg.UnitTests
             var doc = GenerateLexerTestFile("fill: #ff00; stroke: #00ff00");
             var path = doc.GetElementById<SvgPath>("path1");
             // default fill color is Black
-            Assert.AreEqual(System.Drawing.Color.Black, ((SvgColourServer)path.Fill).Colour);
-            Assert.AreEqual(System.Drawing.Color.Lime, ((SvgColourServer)path.Stroke).Colour);
+            Assert.AreEqual(System.Drawing.Color.FromArgb(0,255,255,0), ((SvgColourServer)path.Fill).Colour);
+            Assert.AreEqual(System.Drawing.Color.FromArgb( 0, 255, 0), ((SvgColourServer)path.Stroke).Colour);
         }
 
         [Test]
@@ -75,7 +75,7 @@ namespace Svg.UnitTests
         {
             var doc = GenerateLexerTestFile("fill: #fff; stroke: 005577");
             var path = doc.GetElementById<SvgPath>("path1");
-            Assert.AreEqual(System.Drawing.Color.White, ((SvgColourServer)path.Fill).Colour);
+            Assert.AreEqual(System.Drawing.Color.FromArgb(255, 255, 255), ((SvgColourServer)path.Fill).Colour);
             // default stroke color is null (transparent)
             Assert.IsNull(path.Stroke);
         }

--- a/Tests/Svg.UnitTests/LexerIssueTests.cs
+++ b/Tests/Svg.UnitTests/LexerIssueTests.cs
@@ -60,7 +60,7 @@ namespace Svg.UnitTests
         }
 
         [Test]
-        public void Lexer_FileWithInvalidHex_ColorTagOnlyReverstToDefaultForTheInvalidTag()
+        public void Lexer_FileWithValid4Hex_ColorTagOnly()
         {
             // invalid/valid color combinations - default color is used for each invalid color
             var doc = GenerateLexerTestFile("fill: #ff00; stroke: #00ff00");
@@ -68,6 +68,26 @@ namespace Svg.UnitTests
             // default fill color is Black
             Assert.AreEqual(System.Drawing.Color.FromArgb(0,255,255,0), ((SvgColourServer)path.Fill).Colour);
             Assert.AreEqual(System.Drawing.Color.FromArgb( 0, 255, 0), ((SvgColourServer)path.Stroke).Colour);
+        }
+
+        [Test]
+        public void Lexer_FileWithValid4Hex_ColorTag()
+        {
+            // invalid/valid color combinations - default color is used for each invalid color
+            var doc = GenerateLexerTestFile("fill: #ff00");
+            var path = doc.GetElementById<SvgPath>("path1");
+            // default fill color is Black
+            Assert.AreEqual(System.Drawing.Color.FromArgb(0,255,255,0), ((SvgColourServer)path.Fill).Colour);
+        }
+
+        [Test]
+        public void Lexer_FileWithInvalid2Hex_ColorTagOnlyRevertsToDefaultForTheInvalidTag()
+        {
+            // invalid/valid color combinations - default color is used for each invalid color
+            var doc = GenerateLexerTestFile("fill: #ff");
+            var path = doc.GetElementById<SvgPath>("path1");
+            // default fill color is Black
+            Assert.AreEqual(System.Drawing.Color.Black, ((SvgColourServer)path.Fill).Colour);
         }
 
         [Test]

--- a/Tests/Svg.UnitTests/LexerIssueTests.cs
+++ b/Tests/Svg.UnitTests/LexerIssueTests.cs
@@ -84,10 +84,11 @@ namespace Svg.UnitTests
         public void Lexer_FileWithInvalid2Hex_ColorTagOnlyRevertsToDefaultForTheInvalidTag()
         {
             // invalid/valid color combinations - default color is used for each invalid color
-            var doc = GenerateLexerTestFile("fill: #ff");
+            var doc = GenerateLexerTestFile("fill: #ff; stroke: #00ff00");
             var path = doc.GetElementById<SvgPath>("path1");
             // default fill color is Black
             Assert.AreEqual(System.Drawing.Color.Black, ((SvgColourServer)path.Fill).Colour);
+            Assert.AreEqual(System.Drawing.Color.FromArgb( 0, 255, 0), ((SvgColourServer)path.Stroke).Colour);
         }
 
         [Test]

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -5,6 +5,7 @@ The release versions are NuGet releases.
 
 ### Changes
 * removed out of support framework versions .NET 5 (replaced with .NET 6) (see PR [#1045](https://github.com/svg-net/SVG/pull/1045))
+* updated ExCSS to Version 4.2.1 (see PR[#1083] https://github.com/svg-net/SVG/pull/1083
 
 ### Fixes
 * fixed build error in C# 11 (see [PR #1030](https://github.com/svg-net/SVG/pull/1030))


### PR DESCRIPTION
#### Reference Issue
https://github.com/svg-net/SVG/discussions/1073
#### What does this implement/fix? Explain your changes.
Updates ExCss to the newest Version and fixes Unit Tests for that.