### PR TITLE
Add Svg.Custom Project so that NO_SDC PreCompiler Constants is recogn…

### DIFF
--- a/Source/Svg.sln
+++ b/Source/Svg.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.8.34004.107
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29215.179
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Svg", "Svg.csproj", "{886A98C5-37C0-4E8B-885E-30C1D2F98B47}"
 EndProject

--- a/Source/Svg.sln
+++ b/Source/Svg.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29215.179
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34004.107
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Svg", "Svg.csproj", "{886A98C5-37C0-4E8B-885E-30C1D2F98B47}"
 EndProject
@@ -37,6 +37,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Svg.Benchmark", "..\Tests\Svg.Benchmark\Svg.Benchmark.csproj", "{8DEB3EA7-5915-4EB9-8052-85A7AC4379EC}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Generators", "Generators", "{FAFD6DC7-5203-4CED-A151-66379DD43695}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Svg.Custom", "..\Svg.Custom\Svg.Custom.csproj", "{6FAA2B79-FE5C-456B-A743-E9290665B223}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -84,6 +86,10 @@ Global
 		{8DEB3EA7-5915-4EB9-8052-85A7AC4379EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8DEB3EA7-5915-4EB9-8052-85A7AC4379EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8DEB3EA7-5915-4EB9-8052-85A7AC4379EC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6FAA2B79-FE5C-456B-A743-E9290665B223}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6FAA2B79-FE5C-456B-A743-E9290665B223}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6FAA2B79-FE5C-456B-A743-E9290665B223}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6FAA2B79-FE5C-456B-A743-E9290665B223}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Svg.Custom/Svg.Custom.csproj
+++ b/Svg.Custom/Svg.Custom.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  >
 	<!--Svg Custom Project so that the NO_SDC is detected as used and not optimized away or broken. The original csproj is found here. -->
 	<!-- https://github.com/wieslawsoltes/Svg.Skia/blob/master/src/Svg.Custom/Svg.Custom.csproj -->
   <PropertyGroup>

--- a/Svg.Custom/Svg.Custom.csproj
+++ b/Svg.Custom/Svg.Custom.csproj
@@ -1,0 +1,69 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
+    <EnableDefaultItems>False</EnableDefaultItems>
+    <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
+    <NoWarn>CS1591;SYSLIB0014</NoWarn>
+    <IsPackable>True</IsPackable>
+    <Nullable>disable</Nullable>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\$(Configuration)\$(TargetFramework)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
+    <DefineConstants>$(DefineConstants);NO_SDC</DefineConstants>
+	<LangVersion>10.0</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Description>Custom build of the SVG rendering library.</Description>
+    <PackageId>Svg.Custom</PackageId>
+    <PackageLicenseExpression>MS-PL</PackageLicenseExpression>
+    <PackageTags>svg;vector graphics;rendering;2d;graphics;geometry;shapes</PackageTags>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SvgSourcesBasePath>..</SvgSourcesBasePath>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <!-- https://github.com/vvvv/SVG/blob/master/Source/SvgDtdResolver.cs#L32 -->
+    <EmbeddedResource Include="$(SvgSourcesBasePath)\Source\Resources\svg11.dtd">
+      <Link>Resources\svg11.dtd</Link>
+      <LogicalName>Svg.Resources.svg11.dtd</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="**\*.cs" Exclude="bin\**;obj\**" />
+    <Compile Include="$(SvgSourcesBasePath)\Source\**\*.cs" Exclude="$(SvgSourcesBasePath)\Source\obj\**" />
+    <Compile Remove="$(SvgSourcesBasePath)\Source\Properties\AssemblyInfo.cs" />
+    <Compile Remove="$(SvgSourcesBasePath)\Source\Resources\svg11.dtd" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+    <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD20</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
+    <DefineConstants>$(DefineConstants);NETCORE;NET6</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">        
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Fizzler" Version="1.2.1" />
+    <PackageReference Include="ExCSS" Version="4.1.4" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);USE_SOURCE_GENERATORS</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SvgSourcesBasePath)\Generators\Svg.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/Svg.Custom/Svg.Custom.csproj
+++ b/Svg.Custom/Svg.Custom.csproj
@@ -50,7 +50,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">        
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Svg.Custom/Svg.Custom.csproj
+++ b/Svg.Custom/Svg.Custom.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  >
+	<!--Svg Custom Project so that the NO_SDC is detected as used and not optimized away or broken. The original csproj is found here. -->
+	<!-- https://github.com/wieslawsoltes/Svg.Skia/blob/master/src/Svg.Custom/Svg.Custom.csproj -->
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>


### PR DESCRIPTION
…ized as used

#### Reference Issue
Because here the NO_SDC Compiler directive was removed because it was not seen as used.
https://github.com/svg-net/SVG/pull/1066

#### What does this implement/fix? Explain your changes.
Adds the Svg.Custom Project from Skia.Svg so that the NO_SDC Compiler directive does not regress.
