### PR TITLE
Fix declaring node also allows to use prefix for namespace

### DIFF
--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -516,7 +516,7 @@ namespace Svg
                     {
                         foreach (var kvp in this.Namespaces)
                         {
-                            if (kvp.Value == this.ElementNamespace && !string.IsNullOrEmpty(kvp.Key))
+                            if (kvp.Value.Equals(this.ElementNamespace) && !string.IsNullOrEmpty(kvp.Key))
                             {
                                 prefix = kvp.Key;
                                 break;

--- a/Source/SvgElement.cs
+++ b/Source/SvgElement.cs
@@ -512,6 +512,17 @@ namespace Svg
                 else
                 {
                     var prefix = writer.LookupPrefix(this.ElementNamespace);
+                    if (prefix == null && !this.ElementNamespace.Equals(SvgNamespaces.SvgNamespace))
+                    {
+                        foreach (var kvp in this.Namespaces)
+                        {
+                            if (kvp.Value == this.ElementNamespace && !string.IsNullOrEmpty(kvp.Key))
+                            {
+                                prefix = kvp.Key;
+                                break;
+                            }
+                        }
+                    }
                     if (prefix == null)
                         writer.WriteStartElement(this.ElementName, this.ElementNamespace);
                     else

--- a/Tests/Svg.UnitTests/SvgDocumentsTests.cs
+++ b/Tests/Svg.UnitTests/SvgDocumentsTests.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 using NUnit.Framework;
 
 namespace Svg.UnitTests
@@ -17,6 +19,49 @@ namespace Svg.UnitTests
             SvgDocument.PointsPerInch = pointsPerInch;
             var comparePointsPerInch = SvgDocument.PointsPerInch;
             Assert.AreEqual(pointsPerInch, comparePointsPerInch, "After setting to null the default Implementation should be taken");
+        }
+
+        [Test]
+        public void WriteNamespaces()
+        {
+            //Write a minimal SVG document with some addtional meta data
+            //Test namespaces and prefixes are applied correctly
+
+            const string NAMESPACE_RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+            const string NAMESPACE_DC = "http://purl.org/dc/elements/1.1/";
+
+            SvgDocument svg = new SvgDocument();
+
+            SvgUnknownElement metadata = new SvgUnknownElement("metadata");
+            NonSvgElement rdfMetadata = new NonSvgElement("RDF", NAMESPACE_RDF);
+            rdfMetadata.Namespaces["rdf"] = NAMESPACE_RDF;
+
+            NonSvgElement rdfMetadataDescription = new NonSvgElement("Description", NAMESPACE_RDF);
+            rdfMetadataDescription.Children.Add(new NonSvgElement("creator", NAMESPACE_DC) { Content = "Hello World" });
+            rdfMetadata.Children.Add(rdfMetadataDescription);
+            metadata.Children.Add(rdfMetadata);
+            svg.Children.Add(metadata);
+
+            string xmlString;
+            using (MemoryStream ms = new MemoryStream())
+            using (StreamReader reader = new StreamReader(ms))
+            {
+                svg.Write(ms);
+                ms.Position = 0;
+                xmlString = reader.ReadToEnd();
+            }
+
+            Assert.AreEqual(@"<?xml version=""1.0"" encoding=""utf-8""?>
+<!DOCTYPE svg PUBLIC ""-//W3C//DTD SVG 1.1//EN"" ""http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"">
+<svg version=""1.1"" xmlns=""http://www.w3.org/2000/svg"" xmlns:xlink=""http://www.w3.org/1999/xlink"" xmlns:xml=""http://www.w3.org/XML/1998/namespace"">
+  <metadata>
+    <rdf:RDF xmlns:rdf=""http://www.w3.org/1999/02/22-rdf-syntax-ns#"">
+      <rdf:Description>
+        <creator xmlns=""http://purl.org/dc/elements/1.1/"">Hello World</creator>
+      </rdf:Description>
+    </rdf:RDF>
+  </metadata>
+</svg>", xmlString);
         }
     }
 }

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -1,6 +1,11 @@
 # SVG.NET Release Notes
 The release versions are NuGet releases.
 
+## [Version X.X.X](https://www.nuget.org/packages/Svg/X.X.X)  (20XX-XX-XX)
+
+### Fixes
+* fixed XML namespace prefixes are also applied for nodes declaring them (see [PR #1106](https://github.com/svg-net/SVG/pull/1106))
+
 ## [Version 3.4.6](https://www.nuget.org/packages/Svg/3.4.6)  (2023-11-16)
 
 ### Fixes

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -1,7 +1,7 @@
 # SVG.NET Release Notes
 The release versions are NuGet releases.
 
-## [Version X.X.X](https://www.nuget.org/packages/Svg/X.X.X)  (20XX-XX-XX)
+## Unreleased
 
 ### Fixes
 * fixed XML namespace prefixes are also applied for nodes declaring them (see [PR #1106](https://github.com/svg-net/SVG/pull/1106))


### PR DESCRIPTION
#### Issue / problem
Writing a SVG file where the namespace of a node is declared as an attribute in this node fails to resolve the namespace prefix.

As a minimal example, assume we want to add some additional meta data to a SVG file:

```
SvgDocument svg = SvgDocument.Open("MyImageWithMetaData.svg");

const string NAMESPACE_RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
const string NAMESPACE_DC = "http://purl.org/dc/elements/1.1/";

SvgUnknownElement metadata = new SvgUnknownElement("metadata");
NonSvgElement rdfMetadata = new NonSvgElement("RDF", NAMESPACE_RDF);
rdfMetadata.Namespaces["rdf"] = NAMESPACE_RDF;

NonSvgElement rdfMetadataDescription = new NonSvgElement("Description", NAMESPACE_RDF);
rdfMetadataDescription.Children.Add(new NonSvgElement("creator", NAMESPACE_DC) { Content = "Hello World" });
rdfMetadata.Children.Add(rdfMetadataDescription);
metadata.Children.Add(rdfMetadata);
svg.Children.Add(metadata);

svg.Write("MyImageWithMetaData.svg");
```

The additional meta data will look like this:
```
<RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
  <rdf:Description />
</RDF>
```
Obviously the namespace here is mentioned twice which is not necessary since (see e.g. [Oracle](https://www.oracle.com/technical-resources/articles/srivastava-namespaces.html) or [w3resource](https://www.w3resource.com/index.php))

> The scope of a declared namespace begins at the element where it is declared and applies to the entire content of that element

which means namespace prefixes can be already used in the node they are declared.

```
<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
  <rdf:Description />
</rdf:RDF>
```

This PR also takes care of this and looks up the namespaces declared in the nodes themselfes.