### PR TITLE
Fixed Conflicts of Pull Request https://github.com/svg-net/SVG/pull/1094

### DIFF
--- a/Source/.cr/personal/FavoritesList/List.xml
+++ b/Source/.cr/personal/FavoritesList/List.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Root Type="DevExpress.CodeRush.Foundation.CodePlaces.Options.FavoritesListContainer">
+  <Options Language="Neutral">
+    <Groups />
+  </Options>
+</Root>

--- a/Source/.cr/personal/FavoritesList/List.xml
+++ b/Source/.cr/personal/FavoritesList/List.xml
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Root Type="DevExpress.CodeRush.Foundation.CodePlaces.Options.FavoritesListContainer">
-  <Options Language="Neutral">
-    <Groups />
-  </Options>
-</Root>


### PR DESCRIPTION
#### Reference Issue
Fixes the Conflicts of this pull request
https://github.com/svg-net/SVG/pull/1094

#### What does this implement/fix? Explain your changes.
SvgDocument has CSS support which is cool. But sometimes you may want to specify an external CSS for an SVG document. This MR adds one more parameter to the SvgDocument.Open method for external CSS.

#### Any other comments?