### PR TITLE
fixed CS8352 in net8

### DIFF
--- a/Source/DataTypes/SvgPointCollection.cs
+++ b/Source/DataTypes/SvgPointCollection.cs
@@ -61,7 +61,7 @@ namespace Svg
             if (value is string s)
             {
                 var coords = s.AsSpan().Trim();
-                var state = new CoordinateParserState(ref coords);
+                var state = new CoordinateParserState(coords);
                 var result = new SvgPointCollection();
                 while (CoordinateParser.TryGetFloat(out var pointValue, ref coords, ref state))
                 {

--- a/Source/Paths/CoordinateParser.cs
+++ b/Source/Paths/CoordinateParser.cs
@@ -24,7 +24,7 @@ namespace Svg
         public int Position;
         public bool HasMore;
 
-        public CoordinateParserState(ref ReadOnlySpan<char> chars)
+        public CoordinateParserState(ReadOnlySpan<char> chars)
         {
             CurrNumState = NumState.Separator;
             NewNumState = NumState.Separator;

--- a/Source/Paths/SvgPathBuilder.cs
+++ b/Source/Paths/SvgPathBuilder.cs
@@ -50,14 +50,14 @@ namespace Svg
                         if (command.Length > 0)
                         {
                             var commandSetTrimmed = pathTrimmed.Slice(start, length).Trim();
-                            var state = new CoordinateParserState(ref commandSetTrimmed);
+                            var state = new CoordinateParserState(commandSetTrimmed);
                             CreatePathSegment(commandSetTrimmed[0], segments, ref state, ref commandSetTrimmed);
                         }
 
                         if (pathLength == i + 1)
                         {
                             var commandSetTrimmed = pathTrimmed.Slice(i, 1).Trim();
-                            var state = new CoordinateParserState(ref commandSetTrimmed);
+                            var state = new CoordinateParserState(commandSetTrimmed);
                             CreatePathSegment(commandSetTrimmed[0], segments, ref state, ref commandSetTrimmed);
                         }
                     }
@@ -70,7 +70,7 @@ namespace Svg
                         if (command.Length > 0)
                         {
                             var commandSetTrimmed = pathTrimmed.Slice(start, length).Trim();
-                            var state = new CoordinateParserState(ref commandSetTrimmed);
+                            var state = new CoordinateParserState(commandSetTrimmed);
                             CreatePathSegment(commandSetTrimmed[0], segments, ref state, ref commandSetTrimmed);
                         }
                     }

--- a/Tests/Svg.Benchmark/CoordinateParserBenchmarks.cs
+++ b/Tests/Svg.Benchmark/CoordinateParserBenchmarks.cs
@@ -11,7 +11,7 @@ namespace Svg.Benchmark
         public void CoordinateParser_TryGetBool()
         {
             var chars = "false".AsSpan().Trim();
-            var state = new CoordinateParserState(ref chars);
+            var state = new CoordinateParserState(chars);
             CoordinateParser.TryGetBool(out var result, ref chars, ref state);
         }
 
@@ -19,7 +19,7 @@ namespace Svg.Benchmark
         public void CoordinateParser_TryGetFloat_Points()
         {
             var chars = "1.6,3.2 1.2,5".AsSpan().Trim();
-            var state = new CoordinateParserState(ref chars);
+            var state = new CoordinateParserState(chars);
             while (CoordinateParser.TryGetFloat(out var result, ref chars, ref state))
             {
             }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
if you try to compile this project in net8, it will show some 

SvgPointCollection.cs(66,89,66,94): error CS8352: Cannot use variable 'state' in this context because it may expose referenced variables outside of their declaration scope

This MR fixes that errors.
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

#### Any other comments?
<!--

-->

<!--
Thanks for contributing!
-->
