### PR TITLE
Fixes empty path issue

### DIFF
--- a/Source/Paths/SvgClosePathSegment.Drawing.cs
+++ b/Source/Paths/SvgClosePathSegment.Drawing.cs
@@ -11,6 +11,10 @@ namespace Svg.Pathing
             graphicsPath.CloseFigure();
 
             var end = start;
+            // Check for empty path, as graphicsPath.PathTypes will throw exception: ArgumentException 
+            if (graphicsPath.PointCount == 0)
+                return end;
+
             var pathTypes = graphicsPath.PathTypes;
             for (var i = graphicsPath.PointCount - 1; i >= 0; --i)
                 if ((pathTypes[i] & 0x7) == 0)

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -5,11 +5,15 @@ The release versions are NuGet releases.
 
 ### Changes
 * added SvgOptions with css parameter to Open so that this can be used for transforming the svgdocument.
+* Split tests SVG/PNG files into Issues and W3C Test Suite. W3C Test Suite files are not automatically downloaded.
+* Repository clean-up, reducing the download zip size from 22MB to 4.5MB.
+
 ### Enhancements
 * made exceptions serializable to be able to cross AppDomain boundaries (see [#826](https://github.com/svg-net/SVG/pull/826))
 
 ### Fixes
 * fixed XML namespace prefixes are also applied for nodes declaring them (see [PR #1106](https://github.com/svg-net/SVG/pull/1106))
+* fixed Parameter is not valid (see [PR #1131](https://github.com/svg-net/SVG/pull/1131))
 
 ## [Version 3.4.6](https://www.nuget.org/packages/Svg/3.4.6)  (2023-11-16)
 


### PR DESCRIPTION
### Description
- Fixes issue #1095 (not the original post, but the follow up with `tiger.svg` file)
- Broken with: Minor optimisations (#1084) commit

The `__tiger.svg` is marked as passing the tests, but the above commit for `3.4.5` breaks it, by not checking for empty path.
Exception:
```bash
Result: TEST FAILED
SVG RENDERING ERROR for __tiger.svg
System.ArgumentException: Parameter is not valid.
   at System.Drawing.Drawing2D.GraphicsPath.get_PathTypes()
```

Original Code (3.4.4 - https://github.com/svg-net/SVG/blob/v3.4.4/Source/Paths/SvgClosePathSegment.Drawing.cs)
```cs
        public override PointF AddToPath(GraphicsPath graphicsPath, PointF start, SvgPathSegmentList parent)
        {
            graphicsPath.CloseFigure();

            var end = start;
            for (var i = graphicsPath.PointCount - 1; i >= 0; --i)
                if ((graphicsPath.PathTypes[i] & 0x7) == 0)
                {
                    end = graphicsPath.PathPoints[i];
                    break;
                }
            return end;
        }
```
Changed Code (3.4.5 - https://github.com/svg-net/SVG/blob/v3.4.5/Source/Paths/SvgClosePathSegment.Drawing.cs)
```cs
        public override PointF AddToPath(GraphicsPath graphicsPath, PointF start, SvgPathSegmentList parent)
        {
            graphicsPath.CloseFigure();

            var end = start;
            var pathTypes = graphicsPath.PathTypes; // ERROR: System.ArgumentException: Parameter is not valid.
            for (var i = graphicsPath.PointCount - 1; i >= 0; --i)
                if ((pathTypes[i] & 0x7) == 0)
                {
                    end = graphicsPath.PathPoints[i];
                    break;
                }
            return end;
        }
```

### Type of change
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] This change does not require a documentation update
- [x] Resolved review issues (no issue raised).

### How Has This Been Tested?
- [x] SvgW3CTestRunner is tested for each supported platform
- [x] Svg.UnitTests tested on command line for each supported platform
- [x] Svg.Benchmarks tested on command line for each supported platform, warnings are as before will be addressed later.