### PR TITLE
Updates to SvgW3CTestRunner

### DIFF
--- a/Tests/SvgW3CTestRunner/BitmapExtensions.cs
+++ b/Tests/SvgW3CTestRunner/BitmapExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Drawing.Imaging;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 
 namespace SvgW3CTestRunner
 {
@@ -61,4 +62,120 @@ namespace SvgW3CTestRunner
             }
         }
     }
+
+    /// <summary>
+    /// Taken from https://web.archive.org/web/20130111215043/http://www.switchonthecode.com/tutorials/csharp-tutorial-convert-a-color-image-to-grayscale
+    /// and slightly modified.
+    /// Image width and height, default threshold and handling of alpha values have been adapted.
+    /// </summary>
+    static class ExtensionMethods
+    {
+        private static readonly int ImageWidth = 64;
+        private static readonly int ImageHeight = 64;
+
+        public static float PercentageDifference(this Image img1, Image img2, byte threshold = 10)
+        {
+            byte[,] differences = img1.GetDifferences(img2);
+
+            int diffPixels = 0;
+
+            foreach (byte b in differences)
+            {
+                if (b > threshold) { diffPixels++; }
+            }
+
+            return diffPixels / (float)(differences.GetLength(0) * differences.GetLength(1));
+        }
+
+        public static Bitmap Resize(this Image originalImage, int newWidth, int newHeight)
+        {
+            if (originalImage.Width > originalImage.Height)
+                newWidth = originalImage.Width * newHeight / originalImage.Height;
+            else
+                newHeight = originalImage.Height * newWidth / originalImage.Width;
+
+            var smallVersion = new Bitmap(newWidth, newHeight);
+            using (var g = Graphics.FromImage(smallVersion))
+            {
+                g.SmoothingMode = SmoothingMode.HighQuality;
+                g.InterpolationMode = InterpolationMode.HighQualityBicubic;
+                g.PixelOffsetMode = PixelOffsetMode.HighQuality;
+                g.DrawImage(originalImage, 0, 0, smallVersion.Width, smallVersion.Height);
+            }
+
+            return smallVersion;
+        }
+
+        public static byte[,] GetGrayScaleValues(this Bitmap img)
+        {
+            byte[,] grayScale = new byte[img.Width, img.Height];
+
+            for (int y = 0; y < grayScale.GetLength(1); y++)
+            {
+                for (int x = 0; x < grayScale.GetLength(0); x++)
+                {
+                    var alpha = img.GetPixel(x, y).A;
+                    var gray = img.GetPixel(x, y).R;
+                    grayScale[x, y] = (byte)Math.Abs(gray * alpha / 255);
+                }
+            }
+            return grayScale;
+        }
+
+        // the colormatrix needed to grayscale an image
+        static readonly ColorMatrix ColorMatrix = new ColorMatrix(new float[][]
+        {
+            new float[] {.3f, .3f, .3f, 0, 0},
+            new float[] {.59f, .59f, .59f, 0, 0},
+            new float[] {.11f, .11f, .11f, 0, 0},
+            new float[] {0, 0, 0, 1, 0},
+            new float[] {0, 0, 0, 0, 1}
+        });
+
+        public static Bitmap GetGrayScaleVersion(this Bitmap original)
+        {
+            // create a blank bitmap the same size as original
+            // https://web.archive.org/web/20130111215043/http://www.switchonthecode.com/tutorials/csharp-tutorial-convert-a-color-image-to-grayscale
+            var newBitmap = new Bitmap(original.Width, original.Height);
+
+            // get a graphics object from the new image
+            using (var g = Graphics.FromImage(newBitmap))
+            // create some image attributes
+            using (var attributes = new ImageAttributes())
+            {
+                // set the color matrix attribute
+                attributes.SetColorMatrix(ColorMatrix);
+
+                // draw the original image on the new image
+                // using the grayscale color matrix
+                g.DrawImage(original, new Rectangle(0, 0, original.Width, original.Height),
+                    0, 0, original.Width, original.Height, GraphicsUnit.Pixel, attributes);
+            }
+
+            return newBitmap;
+        }
+
+        public static byte[,] GetDifferences(this Image img1, Image img2)
+        {
+            using (var resizedThisOne = img1.Resize(ImageWidth, ImageHeight))
+            using (var thisOne = resizedThisOne.GetGrayScaleVersion())
+            using (var resizedTheOtherOne = img2.Resize(ImageWidth, ImageHeight))
+            using (var theOtherOne = resizedTheOtherOne.GetGrayScaleVersion())
+            {
+                byte[,] differences = new byte[thisOne.Width, thisOne.Height];
+                byte[,] firstGray = thisOne.GetGrayScaleValues();
+                byte[,] secondGray = theOtherOne.GetGrayScaleValues();
+
+                for (int y = 0; y < differences.GetLength(1); y++)
+                {
+                    for (int x = 0; x < differences.GetLength(0); x++)
+                    {
+                        differences[x, y] = (byte)Math.Abs(firstGray[x, y] - secondGray[x, y]);
+                    }
+                }
+                return differences;
+            }
+        }
+    }
+
 }

--- a/Tests/SvgW3CTestRunner/BitmapUtils.cs
+++ b/Tests/SvgW3CTestRunner/BitmapUtils.cs
@@ -1,5 +1,6 @@
 ﻿using System.Drawing.Imaging;
 using System.Drawing;
+using System;
 
 namespace SvgW3CTestRunner
 {
@@ -10,8 +11,10 @@ namespace SvgW3CTestRunner
 #endif
         public static unsafe Bitmap PixelDiff(Bitmap a, Bitmap b)
         {
-            Bitmap output = new Bitmap(a.Width, a.Height, PixelFormat.Format32bppArgb);
-            Rectangle rect = new Rectangle(Point.Empty, a.Size);
+            var width = Math.Min(a.Width, b.Width);
+            var height = Math.Min(a.Height, b.Height);
+            Bitmap output = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+            Rectangle rect = new Rectangle(Point.Empty, new Size(width, height));
             using (var aData = a.LockBitsDisposable(rect, ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb))
             using (var bData = b.LockBitsDisposable(rect, ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb))
             using (var outputData = output.LockBitsDisposable(rect, ImageLockMode.ReadWrite, PixelFormat.Format32bppArgb))

--- a/Tests/SvgW3CTestRunner/ListSearchDialog.Designer.cs
+++ b/Tests/SvgW3CTestRunner/ListSearchDialog.Designer.cs
@@ -117,6 +117,7 @@
             ShowInTaskbar = false;
             StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             Text = "List Search Dialog";
+            Load += OnLoadDialog;
             ResumeLayout(false);
             PerformLayout();
         }

--- a/Tests/SvgW3CTestRunner/ListSearchDialog.cs
+++ b/Tests/SvgW3CTestRunner/ListSearchDialog.cs
@@ -1,11 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace SvgW3CTestRunner
@@ -18,14 +11,12 @@ namespace SvgW3CTestRunner
         public ListSearchDialog()
         {
             InitializeComponent();
-
-            this.Load += OnFormDialogLoad;
         }
 
         public int SeletedTabIndex { get => _seletedTabIndex; set => _seletedTabIndex = value; }
         public ListBox[] ListItems { get => _listItems; set => _listItems = value; }
 
-        private void OnFormDialogLoad(object sender, EventArgs e)
+        private void OnLoadDialog(object sender, EventArgs e)
         {
             if (_listItems != null && _listItems.Length == 4)
             {

--- a/Tests/SvgW3CTestRunner/RunTestsDialog.Designer.cs
+++ b/Tests/SvgW3CTestRunner/RunTestsDialog.Designer.cs
@@ -1,0 +1,222 @@
+﻿namespace SvgW3CTestRunner
+{
+    partial class RunTestsDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            panelTop = new System.Windows.Forms.Panel();
+            buttonRun = new System.Windows.Forms.Button();
+            comboBoxSelectTab = new System.Windows.Forms.ComboBox();
+            labelSelectTab = new System.Windows.Forms.Label();
+            tabControlResults = new System.Windows.Forms.TabControl();
+            tabPageRun = new System.Windows.Forms.TabPage();
+            listView = new System.Windows.Forms.ListView();
+            columnNumber = new System.Windows.Forms.ColumnHeader();
+            columnFileName = new System.Windows.Forms.ColumnHeader();
+            columnException = new System.Windows.Forms.ColumnHeader();
+            columnPercent = new System.Windows.Forms.ColumnHeader();
+            tabPageLog = new System.Windows.Forms.TabPage();
+            richTextBox = new System.Windows.Forms.RichTextBox();
+            panelTop.SuspendLayout();
+            tabControlResults.SuspendLayout();
+            tabPageRun.SuspendLayout();
+            tabPageLog.SuspendLayout();
+            SuspendLayout();
+            // 
+            // panelTop
+            // 
+            panelTop.Controls.Add(buttonRun);
+            panelTop.Controls.Add(comboBoxSelectTab);
+            panelTop.Controls.Add(labelSelectTab);
+            panelTop.Dock = System.Windows.Forms.DockStyle.Top;
+            panelTop.Location = new System.Drawing.Point(3, 3);
+            panelTop.Name = "panelTop";
+            panelTop.Size = new System.Drawing.Size(878, 48);
+            panelTop.TabIndex = 0;
+            // 
+            // buttonRun
+            // 
+            buttonRun.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            buttonRun.Enabled = false;
+            buttonRun.Location = new System.Drawing.Point(621, 8);
+            buttonRun.Name = "buttonRun";
+            buttonRun.Size = new System.Drawing.Size(95, 32);
+            buttonRun.TabIndex = 6;
+            buttonRun.Text = "Run";
+            buttonRun.UseVisualStyleBackColor = true;
+            buttonRun.Click += OnClickRun;
+            // 
+            // comboBoxSelectTab
+            // 
+            comboBoxSelectTab.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            comboBoxSelectTab.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboBoxSelectTab.FormattingEnabled = true;
+            comboBoxSelectTab.Location = new System.Drawing.Point(240, 11);
+            comboBoxSelectTab.Name = "comboBoxSelectTab";
+            comboBoxSelectTab.Size = new System.Drawing.Size(369, 25);
+            comboBoxSelectTab.TabIndex = 3;
+            // 
+            // labelSelectTab
+            // 
+            labelSelectTab.AutoSize = true;
+            labelSelectTab.Location = new System.Drawing.Point(128, 15);
+            labelSelectTab.Name = "labelSelectTab";
+            labelSelectTab.Size = new System.Drawing.Size(100, 17);
+            labelSelectTab.TabIndex = 2;
+            labelSelectTab.Text = "Select Tests Tab";
+            // 
+            // tabControlResults
+            // 
+            tabControlResults.Controls.Add(tabPageRun);
+            tabControlResults.Controls.Add(tabPageLog);
+            tabControlResults.Dock = System.Windows.Forms.DockStyle.Fill;
+            tabControlResults.ItemSize = new System.Drawing.Size(120, 28);
+            tabControlResults.Location = new System.Drawing.Point(3, 51);
+            tabControlResults.Margin = new System.Windows.Forms.Padding(6, 7, 6, 7);
+            tabControlResults.Name = "tabControlResults";
+            tabControlResults.SelectedIndex = 0;
+            tabControlResults.Size = new System.Drawing.Size(878, 557);
+            tabControlResults.SizeMode = System.Windows.Forms.TabSizeMode.Fixed;
+            tabControlResults.TabIndex = 1;
+            // 
+            // tabPageRun
+            // 
+            tabPageRun.Controls.Add(listView);
+            tabPageRun.Location = new System.Drawing.Point(4, 32);
+            tabPageRun.Name = "tabPageRun";
+            tabPageRun.Padding = new System.Windows.Forms.Padding(3);
+            tabPageRun.Size = new System.Drawing.Size(870, 521);
+            tabPageRun.TabIndex = 0;
+            tabPageRun.Text = "Test Results";
+            tabPageRun.UseVisualStyleBackColor = true;
+            // 
+            // listView
+            // 
+            listView.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            listView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] { columnNumber, columnFileName, columnException, columnPercent });
+            listView.Dock = System.Windows.Forms.DockStyle.Fill;
+            listView.FullRowSelect = true;
+            listView.HideSelection = false;
+            listView.Location = new System.Drawing.Point(3, 3);
+            listView.Name = "listView";
+            listView.Size = new System.Drawing.Size(864, 515);
+            listView.TabIndex = 0;
+            listView.UseCompatibleStateImageBehavior = false;
+            listView.View = System.Windows.Forms.View.Details;
+            // 
+            // columnNumber
+            // 
+            columnNumber.Text = "#";
+            // 
+            // columnFileName
+            // 
+            columnFileName.Text = "File name";
+            columnFileName.Width = 500;
+            // 
+            // columnException
+            // 
+            columnException.Text = "Exception";
+            columnException.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            columnException.Width = 80;
+            // 
+            // columnPercent
+            // 
+            columnPercent.Text = "Diff Percent (%)";
+            columnPercent.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            columnPercent.Width = 120;
+            // 
+            // tabPageLog
+            // 
+            tabPageLog.Controls.Add(richTextBox);
+            tabPageLog.Location = new System.Drawing.Point(4, 32);
+            tabPageLog.Name = "tabPageLog";
+            tabPageLog.Padding = new System.Windows.Forms.Padding(3);
+            tabPageLog.Size = new System.Drawing.Size(870, 521);
+            tabPageLog.TabIndex = 1;
+            tabPageLog.Text = "Logs";
+            tabPageLog.UseVisualStyleBackColor = true;
+            // 
+            // richTextBox
+            // 
+            richTextBox.BackColor = System.Drawing.SystemColors.Window;
+            richTextBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            richTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            richTextBox.Location = new System.Drawing.Point(3, 3);
+            richTextBox.Name = "richTextBox";
+            richTextBox.ReadOnly = true;
+            richTextBox.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.ForcedBoth;
+            richTextBox.ShowSelectionMargin = true;
+            richTextBox.Size = new System.Drawing.Size(864, 515);
+            richTextBox.TabIndex = 0;
+            richTextBox.Text = "";
+            richTextBox.WordWrap = false;
+            // 
+            // RunTestsDialog
+            // 
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 17F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(884, 611);
+            Controls.Add(tabControlResults);
+            Controls.Add(panelTop);
+            Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            MaximizeBox = false;
+            MinimizeBox = false;
+            MinimumSize = new System.Drawing.Size(900, 600);
+            Name = "RunTestsDialog";
+            Padding = new System.Windows.Forms.Padding(3);
+            ShowIcon = false;
+            ShowInTaskbar = false;
+            SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
+            StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            Text = "Run Tests";
+            Load += OnLoadDialog;
+            Shown += OnShownDialog;
+            panelTop.ResumeLayout(false);
+            panelTop.PerformLayout();
+            tabControlResults.ResumeLayout(false);
+            tabPageRun.ResumeLayout(false);
+            tabPageLog.ResumeLayout(false);
+            ResumeLayout(false);
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Panel panelTop;
+        private System.Windows.Forms.TabControl tabControlResults;
+        private System.Windows.Forms.TabPage tabPageRun;
+        private System.Windows.Forms.TabPage tabPageLog;
+        private System.Windows.Forms.RichTextBox richTextBox;
+        private System.Windows.Forms.ComboBox comboBoxSelectTab;
+        private System.Windows.Forms.Label labelSelectTab;
+        private System.Windows.Forms.Button buttonRun;
+        private System.Windows.Forms.ListView listView;
+        private System.Windows.Forms.ColumnHeader columnNumber;
+        private System.Windows.Forms.ColumnHeader columnFileName;
+        private System.Windows.Forms.ColumnHeader columnPercent;
+        private System.Windows.Forms.ColumnHeader columnException;
+    }
+}

--- a/Tests/SvgW3CTestRunner/RunTestsDialog.cs
+++ b/Tests/SvgW3CTestRunner/RunTestsDialog.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+using Svg;
+
+namespace SvgW3CTestRunner
+{
+    public partial class RunTestsDialog : Form
+    {
+        private const string IssuesPrefix = "__";
+
+        private sealed class TestItem
+        {
+            public int number;
+            public string fileName;
+            public bool exception;
+            public double percentage;
+
+            public TestItem(int number, string fileName)
+            {
+                this.number = number;
+                this.fileName = fileName;
+            }
+
+            public string[] ToList()
+            {
+                return new string[] {
+                    number.ToString(),
+                    fileName,
+                    exception ? "Yes" : "No",
+                    percentage.ToString()
+                };
+            }
+        }
+
+
+        private int _seletedTabIndex;
+        private List<string[]> _listItems;
+
+        private List<TestItem> _testItems;
+
+        //Data folders
+        private string _svgW3CBasePath;
+        private string _pngW3CBasePath;
+
+        //Data folders
+        private string _svgIssuesBasePath;
+        private string _pngIssuesBasePath;
+
+        private ListViewGroup testGroup;
+        private ListViewGroup exceptionGroup;
+
+        public RunTestsDialog()
+        {
+            InitializeComponent();
+
+            // Add some groups to the ListView.
+            testGroup = new ListViewGroup("Test Results");
+            exceptionGroup = new ListViewGroup("Exception Results");
+            listView.Groups.Add(testGroup);
+            listView.Groups.Add(exceptionGroup);
+
+            columnNumber.TextAlign = HorizontalAlignment.Right;
+        }
+
+        public int SeletedTabIndex { get => _seletedTabIndex; set => _seletedTabIndex = value; }
+        public List<string[]> ListItems { get => _listItems; set => _listItems = value; }
+
+        public string SvgW3CBasePath { get => _svgW3CBasePath; set => _svgW3CBasePath = value; }
+        public string PngW3CBasePath { get => _pngW3CBasePath; set => _pngW3CBasePath = value; }
+        public string SvgIssuesBasePath { get => _svgIssuesBasePath; set => _svgIssuesBasePath = value; }
+        public string PngIssuesBasePath { get => _pngIssuesBasePath; set => _pngIssuesBasePath = value; }
+
+        private void OnLoadDialog(object sender, EventArgs e)
+        {
+            if (_listItems != null && _listItems.Count == 4)
+            {
+                comboBoxSelectTab.Items.Add("Pass W3C");
+                comboBoxSelectTab.Items.Add("Fail W3C");
+                comboBoxSelectTab.Items.Add("Pass Other");
+                comboBoxSelectTab.Items.Add("Fail Other");
+
+                comboBoxSelectTab.SelectedIndex = _seletedTabIndex;
+                buttonRun.Enabled = true;
+            }
+        }
+
+        private void OnShownDialog(object sender, EventArgs e)
+        {
+            richTextBox.Select();
+        }
+
+        private void OnClickRun(object sender, EventArgs e)
+        {
+            if (_testItems == null || _testItems.Count != 0)
+            {
+                _testItems = new List<TestItem>();
+            }
+            if (_listItems == null || _listItems.Count != 4)
+            {
+                return;
+            }
+
+            richTextBox.Clear();
+            listView.Items.Clear();
+
+            _seletedTabIndex = comboBoxSelectTab.SelectedIndex;
+
+            this.Cursor = Cursors.WaitCursor;
+            string fileName = string.Empty;
+            try
+            {
+                var selectedItems = _listItems[_seletedTabIndex];
+                for (int index = 0; index < selectedItems.Length; index++)
+                {
+                    fileName = selectedItems[index];
+                    RunTest(fileName);
+                }
+            }
+            catch (Exception ex)
+            {
+                if (richTextBox.TextLength != 0)
+                {
+                    richTextBox.AppendText(Environment.NewLine);
+                }
+                richTextBox.AppendText($"Exception: {fileName}" + Environment.NewLine);
+                richTextBox.AppendText(ex.ToString());
+                richTextBox.AppendText(Environment.NewLine);
+            }
+            finally
+            {
+                foreach (var testItem in _testItems)
+                {
+                    ListViewItem viewItem = listView.Items.Add(new ListViewItem(testItem.ToList(), testGroup));
+                    viewItem.Tag = fileName;
+
+                    if (testItem.exception)
+                    {
+                        viewItem.BackColor = Color.Crimson;
+                        listView.Items.Add(new ListViewItem(testItem.ToList(), exceptionGroup));
+                    }
+                }
+
+                this.Cursor = Cursors.Default;
+            }
+        }
+
+        private void RunTest(string fileName)
+        {
+#if NET5_0_OR_GREATER
+            if (!OperatingSystem.IsWindows())
+                return;
+#endif
+
+            TestItem testItem = new TestItem(_testItems.Count, fileName);
+            _testItems.Add(testItem);
+
+            var isIssue = fileName.StartsWith(IssuesPrefix);
+
+            var pngBasePath = isIssue ? _pngIssuesBasePath : _pngW3CBasePath;
+            var svgBasePath = isIssue ? _svgIssuesBasePath : _svgW3CBasePath;
+
+            Image pngImage = null;
+            Image svgImage = null;
+            try
+            {
+                pngImage = Image.FromFile(Path.Combine(pngBasePath, Path.ChangeExtension(fileName, "png")));
+
+                var doc = new SvgDocument();
+                doc = SvgDocument.Open(Path.Combine(svgBasePath, fileName));
+                if (isIssue)
+                {
+                    svgImage = doc.Draw();
+                    // Check for a large difference in image size, if not nearly equal recreate it
+                    if (Math.Abs(svgImage.Width - pngImage.Width) > 10 || Math.Abs(svgImage.Height - pngImage.Height) > 10)
+                    {
+                        svgImage.Dispose();
+                        svgImage = new Bitmap(pngImage.Width, pngImage.Height);
+                        doc.Draw((Bitmap)svgImage);
+                    }
+                }
+                else
+                {
+                    svgImage = new Bitmap(480, 360);
+                    doc.Draw((Bitmap)svgImage);
+                }
+
+                var difference = svgImage.PercentageDifference(pngImage);
+                var percentage = Math.Round(difference * 100.0, 2);
+
+                testItem.percentage = percentage;
+            }
+            catch (Exception ex)
+            {
+                testItem.exception = true;
+
+                if (richTextBox.TextLength != 0)
+                {
+                    richTextBox.AppendText(Environment.NewLine);
+                }
+                richTextBox.AppendText($"Exception: {fileName}" + Environment.NewLine);
+                richTextBox.AppendText(ex.ToString());
+                richTextBox.AppendText(Environment.NewLine);
+            }
+            finally
+            {
+                pngImage?.Dispose();
+                svgImage?.Dispose();
+
+                testItem.number = _testItems.Count;
+            }
+        }
+    }
+}

--- a/Tests/SvgW3CTestRunner/RunTestsDialog.resx
+++ b/Tests/SvgW3CTestRunner/RunTestsDialog.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Tests/SvgW3CTestRunner/View.Designer.cs
+++ b/Tests/SvgW3CTestRunner/View.Designer.cs
@@ -53,6 +53,9 @@ namespace SvgW3CTestRunner
             lstFilesOtherPassing = new System.Windows.Forms.ListBox();
             failOtherTabPage = new System.Windows.Forms.TabPage();
             lstFilesOtherFailing = new System.Windows.Forms.ListBox();
+            panelButtons = new System.Windows.Forms.Panel();
+            buttonFind = new System.Windows.Forms.Button();
+            buttonRun = new System.Windows.Forms.Button();
             bottomTabBox = new System.Windows.Forms.TabControl();
             outputTab = new System.Windows.Forms.TabPage();
             boxConsoleLog = new System.Windows.Forms.RichTextBox();
@@ -76,6 +79,7 @@ namespace SvgW3CTestRunner
             failW3CTabPage.SuspendLayout();
             passOtherTabPage.SuspendLayout();
             failOtherTabPage.SuspendLayout();
+            panelButtons.SuspendLayout();
             bottomTabBox.SuspendLayout();
             outputTab.SuspendLayout();
             descriptionTab.SuspendLayout();
@@ -236,6 +240,7 @@ namespace SvgW3CTestRunner
             // 
             splitContainerBase.Panel1.BackColor = SystemColors.Control;
             splitContainerBase.Panel1.Controls.Add(fileTabBox);
+            splitContainerBase.Panel1.Controls.Add(panelButtons);
             // 
             // splitContainerBase.Panel2
             // 
@@ -259,7 +264,7 @@ namespace SvgW3CTestRunner
             fileTabBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             fileTabBox.Name = "fileTabBox";
             fileTabBox.SelectedIndex = 0;
-            fileTabBox.Size = new Size(278, 992);
+            fileTabBox.Size = new Size(278, 956);
             fileTabBox.SizeMode = System.Windows.Forms.TabSizeMode.Fixed;
             fileTabBox.TabIndex = 3;
             fileTabBox.SelectedIndexChanged += fileTabBox_TabIndexChanged;
@@ -270,7 +275,7 @@ namespace SvgW3CTestRunner
             passW3CTabPage.Location = new Point(4, 32);
             passW3CTabPage.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             passW3CTabPage.Name = "passW3CTabPage";
-            passW3CTabPage.Size = new Size(270, 956);
+            passW3CTabPage.Size = new Size(270, 920);
             passW3CTabPage.TabIndex = 0;
             passW3CTabPage.Text = "Pass W3C";
             passW3CTabPage.UseVisualStyleBackColor = true;
@@ -283,7 +288,7 @@ namespace SvgW3CTestRunner
             lstW3CFilesPassing.Location = new Point(0, 0);
             lstW3CFilesPassing.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             lstW3CFilesPassing.Name = "lstW3CFilesPassing";
-            lstW3CFilesPassing.Size = new Size(270, 956);
+            lstW3CFilesPassing.Size = new Size(270, 920);
             lstW3CFilesPassing.TabIndex = 1;
             lstW3CFilesPassing.SelectedIndexChanged += OnW3CSelectedIndexChanged;
             // 
@@ -293,7 +298,7 @@ namespace SvgW3CTestRunner
             failW3CTabPage.Location = new Point(4, 32);
             failW3CTabPage.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             failW3CTabPage.Name = "failW3CTabPage";
-            failW3CTabPage.Size = new Size(270, 956);
+            failW3CTabPage.Size = new Size(270, 920);
             failW3CTabPage.TabIndex = 1;
             failW3CTabPage.Text = "Fail W3C";
             failW3CTabPage.UseVisualStyleBackColor = true;
@@ -306,7 +311,7 @@ namespace SvgW3CTestRunner
             lstW3CFilesFailing.Location = new Point(0, 0);
             lstW3CFilesFailing.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             lstW3CFilesFailing.Name = "lstW3CFilesFailing";
-            lstW3CFilesFailing.Size = new Size(270, 956);
+            lstW3CFilesFailing.Size = new Size(270, 920);
             lstW3CFilesFailing.TabIndex = 0;
             lstW3CFilesFailing.SelectedIndexChanged += OnW3CSelectedIndexChanged;
             // 
@@ -316,7 +321,7 @@ namespace SvgW3CTestRunner
             passOtherTabPage.Location = new Point(4, 32);
             passOtherTabPage.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             passOtherTabPage.Name = "passOtherTabPage";
-            passOtherTabPage.Size = new Size(270, 956);
+            passOtherTabPage.Size = new Size(270, 920);
             passOtherTabPage.TabIndex = 2;
             passOtherTabPage.Text = "Pass Other";
             passOtherTabPage.UseVisualStyleBackColor = true;
@@ -329,7 +334,7 @@ namespace SvgW3CTestRunner
             lstFilesOtherPassing.Location = new Point(0, 0);
             lstFilesOtherPassing.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             lstFilesOtherPassing.Name = "lstFilesOtherPassing";
-            lstFilesOtherPassing.Size = new Size(270, 956);
+            lstFilesOtherPassing.Size = new Size(270, 920);
             lstFilesOtherPassing.TabIndex = 0;
             lstFilesOtherPassing.SelectedIndexChanged += OnIssuesSelectedIndexChanged;
             // 
@@ -339,7 +344,7 @@ namespace SvgW3CTestRunner
             failOtherTabPage.Location = new Point(4, 32);
             failOtherTabPage.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             failOtherTabPage.Name = "failOtherTabPage";
-            failOtherTabPage.Size = new Size(270, 956);
+            failOtherTabPage.Size = new Size(270, 920);
             failOtherTabPage.TabIndex = 2;
             failOtherTabPage.Text = "Fail Other";
             failOtherTabPage.UseVisualStyleBackColor = true;
@@ -352,9 +357,43 @@ namespace SvgW3CTestRunner
             lstFilesOtherFailing.Location = new Point(0, 0);
             lstFilesOtherFailing.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             lstFilesOtherFailing.Name = "lstFilesOtherFailing";
-            lstFilesOtherFailing.Size = new Size(270, 956);
+            lstFilesOtherFailing.Size = new Size(270, 920);
             lstFilesOtherFailing.TabIndex = 0;
             lstFilesOtherFailing.SelectedIndexChanged += OnIssuesSelectedIndexChanged;
+            // 
+            // panelButtons
+            // 
+            panelButtons.Controls.Add(buttonFind);
+            panelButtons.Controls.Add(buttonRun);
+            panelButtons.Dock = System.Windows.Forms.DockStyle.Bottom;
+            panelButtons.Location = new Point(0, 956);
+            panelButtons.Name = "panelButtons";
+            panelButtons.Size = new Size(278, 36);
+            panelButtons.TabIndex = 4;
+            // 
+            // buttonFind
+            // 
+            buttonFind.Dock = System.Windows.Forms.DockStyle.Right;
+            buttonFind.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            buttonFind.Location = new Point(203, 0);
+            buttonFind.Name = "buttonFind";
+            buttonFind.Size = new Size(75, 36);
+            buttonFind.TabIndex = 1;
+            buttonFind.Text = "Search";
+            buttonFind.UseVisualStyleBackColor = true;
+            buttonFind.Click += OnClickSearch;
+            // 
+            // buttonRun
+            // 
+            buttonRun.Dock = System.Windows.Forms.DockStyle.Left;
+            buttonRun.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            buttonRun.Location = new Point(0, 0);
+            buttonRun.Name = "buttonRun";
+            buttonRun.Size = new Size(75, 36);
+            buttonRun.TabIndex = 0;
+            buttonRun.Text = "Run Tests";
+            buttonRun.UseVisualStyleBackColor = true;
+            buttonRun.Click += OnClickRunTests;
             // 
             // bottomTabBox
             // 
@@ -448,6 +487,7 @@ namespace SvgW3CTestRunner
             failW3CTabPage.ResumeLayout(false);
             passOtherTabPage.ResumeLayout(false);
             failOtherTabPage.ResumeLayout(false);
+            panelButtons.ResumeLayout(false);
             bottomTabBox.ResumeLayout(false);
             outputTab.ResumeLayout(false);
             descriptionTab.ResumeLayout(false);
@@ -484,6 +524,9 @@ namespace SvgW3CTestRunner
         private System.Windows.Forms.Panel panelSVGPNG;
         private System.Windows.Forms.Label labelSVGPNG;
         private System.Windows.Forms.PictureBox picSVGPNG;
+        private System.Windows.Forms.Panel panelButtons;
+        private System.Windows.Forms.Button buttonFind;
+        private System.Windows.Forms.Button buttonRun;
     }
 }
 


### PR DESCRIPTION
### Description
- Fixes exception in pixel difference calculations due to image size difference
- Added difference percentage calculations from Svg.UnitTests
- Added a test-run dialog to quickly calculation tests in a selected tab
- Added buttons to access the search and test-run dialogs

Exception:
```bash
WC3 TEST struct-image-15-f.svg
Result: TEST FAILED
SVG TO PNG COMPARISON ERROR for struct-image-15-f.svg
System.ArgumentException: Parameter is not valid.
   at System.Drawing.Bitmap.LockBits(Rectangle rect, ImageLockMode flags, PixelFormat format)
   at SvgW3CTestRunner.BitmapExtensions.DisposableImageData..ctor(Bitmap bitmap, Rectangle rect, ImageLockMode flags, PixelFormat format) in ...\SVG\Tests\SvgW3CTestRunner\BitmapExtensions.cs:line 26

WC3 TEST struct-image-14-f.svg
Result: TEST FAILED
SVG TO PNG COMPARISON ERROR for struct-image-14-f.svg
System.ArgumentException: Parameter is not valid.
   at System.Drawing.Bitmap.LockBits(Rectangle rect, ImageLockMode flags, PixelFormat format)
   at SvgW3CTestRunner.BitmapExtensions.DisposableImageData..ctor(Bitmap bitmap, Rectangle rect, ImageLockMode flags, PixelFormat format) in ...SVG\Tests\SvgW3CTestRunner\BitmapExtensions.cs:line 26

WC3 TEST struct-image-13-f.svg
Result: TEST FAILED
SVG TO PNG COMPARISON ERROR for struct-image-13-f.svg
System.ArgumentException: Parameter is not valid.
   at System.Drawing.Bitmap.LockBits(Rectangle rect, ImageLockMode flags, PixelFormat format)
```

### Type of change
- [x] Bug fixes, no change in main source codes (non-breaking change which fixes an issue)
- [x] This change does not require a documentation update
- [ ] Resolved review issues.

### How Has This Been Tested?
- [x] SvgW3CTestRunner is tested for each supported platform
- [x] Svg.UnitTests tested on command line for each supported platform
- [x] Svg.Benchmarks tested on command line for each supported platform, warnings are as before will be addressed later.