### PR TITLE
Added support for .NET 8

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -1,7 +1,11 @@
 name: Testsuite
 
 on:
-  [push, pull_request]
+  workflow_dispatch: # Allows manual triggering of workflow
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
 
 jobs:
   test:
@@ -11,7 +15,7 @@ jobs:
       matrix:
         os: [windows-latest]
         # os: [windows-latest, ubuntu-latest]
-        framework: [netcoreapp3.1, net6.0, net462]
+        framework: [net8.0, net6.0, netcoreapp3.1, net462]
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
@@ -25,16 +29,16 @@ jobs:
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget }}
-      - name: Setup .NET 3.1 SDK
-        uses: actions/setup-dotnet@v3
+      - name: Setup .NET 8.0.x SDK
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 8.0.x
           include-prerelease: false
       - name: Restore NuGet Packages
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           nuget restore Source/Svg.sln
-          nuget install NUnit.ConsoleRunner -Version 3.10.0 -OutputDirectory tools
+          nuget install NUnit.ConsoleRunner -Version 3.17.0 -OutputDirectory tools
       - name: Run tests
         env:
           DOTNET_NOLOGO: true
@@ -49,7 +53,7 @@ jobs:
         benchmark: [SvgDocument, SvgPathBuilder, SvgTransformConverter, CoordinateParser]
         os: [windows-latest]
         # os: [windows-latest, ubuntu-latest]
-        framework: [netcoreapp3.1]
+        framework: [net8.0]
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
@@ -63,10 +67,10 @@ jobs:
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-bench }}
-      - name: Setup .NET 3.1 SDK
-        uses: actions/setup-dotnet@v3
+      - name: Setup .NET 8.x SDK
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 8.0.x
           include-prerelease: false
       - name: Restore NuGet Packages
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -24,16 +24,17 @@ jobs:
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1
       - name: Cache NuGet packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         id: cache
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget }}
-      - name: Setup .NET 8.0.x SDK
+      - name: Setup .NET 3.1/8.0 SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
-          include-prerelease: false
+          dotnet-version: |
+            3.1.x
+            8.0.x
       - name: Restore NuGet Packages
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
@@ -62,7 +63,7 @@ jobs:
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1
       - name: Cache NuGet packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         id: cache
         with:
           path: ~/.nuget/packages
@@ -71,7 +72,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
-          include-prerelease: false
       - name: Restore NuGet Packages
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Restore NuGet Packages
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          nuget restore Source/Svg.sln
+          nuget restore Tests/Svg.UnitTests.sln
           nuget install NUnit.ConsoleRunner -Version 3.17.0 -OutputDirectory tools
       - name: Run tests
         env:
@@ -75,7 +75,7 @@ jobs:
       - name: Restore NuGet Packages
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          nuget restore Source/Svg.sln
+          nuget restore Tests/Svg.Benchmark.sln
       - name: Run benchmarks
         env:
           DOTNET_NOLOGO: true

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -18,7 +18,7 @@ jobs:
         framework: [net8.0, net6.0, netcoreapp3.1, net462]
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # needed for GitVersioning to work
       - name: Setup NuGet
@@ -45,7 +45,7 @@ jobs:
           DOTNET_NOLOGO: true
           DOTNET_CLI_TELEMETRY_OPTOUT: true
         run: |
-          dotnet test --framework ${{ matrix.framework }} Tests/Svg.UnitTests/Svg.UnitTests.csproj
+          dotnet test -c Release -f ${{ matrix.framework }} Tests/Svg.UnitTests/Svg.UnitTests.csproj
           
   benchmark:
     runs-on: ${{ matrix.os }}
@@ -57,7 +57,7 @@ jobs:
         framework: [net8.0]
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup NuGet

--- a/Generators/Svg.Generators.csproj
+++ b/Generators/Svg.Generators.csproj
@@ -8,6 +8,15 @@
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+        <Configurations>Debug;Release</Configurations>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <NoWarn>$(NoWarn);CS0618</NoWarn>
+    </PropertyGroup>
+    
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <NoWarn>$(NoWarn);CS1591;CS0618</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Generators/Svg.Generators.csproj
+++ b/Generators/Svg.Generators.csproj
@@ -12,7 +12,6 @@
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <NoWarn>$(NoWarn);CS0618</NoWarn>
     </PropertyGroup>
     
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/Samples/Entities/Entities.csproj
+++ b/Samples/Entities/Entities.csproj
@@ -3,10 +3,11 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
+        <Configurations>Debug;Release</Configurations>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <NoWarn>$(NoWarn);CS0618;NETSDK1138</NoWarn>
+        <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
         <NoWarn>$(NoWarn);CS1591;CS0618;NETSDK1138</NoWarn>

--- a/Samples/SVGBuilder/Properties/AssemblyInfo.cs
+++ b/Samples/SVGBuilder/Properties/AssemblyInfo.cs
@@ -34,3 +34,6 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+#if NET5_0_OR_GREATER
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("windows7.0")]
+#endif

--- a/Samples/SVGBuilder/SVGBuilder.csproj
+++ b/Samples/SVGBuilder/SVGBuilder.csproj
@@ -6,10 +6,11 @@
         <UseWindowsForms>true</UseWindowsForms>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+        <Configurations>Debug;Release</Configurations>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <NoWarn>$(NoWarn);CS0618;NETSDK1138</NoWarn>
+        <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
         <NoWarn>$(NoWarn);CS1591;CS0618;NETSDK1138</NoWarn>

--- a/Samples/SVGBuilder/SVGBuilder.csproj
+++ b/Samples/SVGBuilder/SVGBuilder.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFrameworks>net6.0-windows;net462</TargetFrameworks>
+        <TargetFrameworks>net8.0-windows;net6.0-windows;net462</TargetFrameworks>
         <UseWindowsForms>true</UseWindowsForms>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>

--- a/Samples/SVGViewer/Properties/AssemblyInfo.cs
+++ b/Samples/SVGViewer/Properties/AssemblyInfo.cs
@@ -34,3 +34,6 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+#if NET5_0_OR_GREATER
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("windows7.0")]
+#endif

--- a/Samples/SVGViewer/SVGViewer.csproj
+++ b/Samples/SVGViewer/SVGViewer.csproj
@@ -6,10 +6,11 @@
         <UseWindowsForms>true</UseWindowsForms>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+        <Configurations>Debug;Release</Configurations>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <NoWarn>$(NoWarn);CS0618;NETSDK1138</NoWarn>
+        <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
         <NoWarn>$(NoWarn);CS1591;CS0618;NETSDK1138</NoWarn>

--- a/Samples/SVGViewer/SVGViewer.csproj
+++ b/Samples/SVGViewer/SVGViewer.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFrameworks>net6.0-windows;net462</TargetFrameworks>
+        <TargetFrameworks>net8.0-windows;net6.0-windows;net462</TargetFrameworks>
         <UseWindowsForms>true</UseWindowsForms>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>

--- a/Samples/SvgConsole/SvgConsole.csproj
+++ b/Samples/SvgConsole/SvgConsole.csproj
@@ -8,15 +8,13 @@
         <PackAsTool>True</PackAsTool>
         <ToolCommandName>SvgConsole</ToolCommandName>
         <LangVersion>7.3</LangVersion>
-    </PropertyGroup>
-
-    <PropertyGroup>
+        <Configurations>Debug;Release</Configurations>
         <PublishTrimmed>False</PublishTrimmed>
         <PublishReadyToRun>False</PublishReadyToRun>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <NoWarn>$(NoWarn);CS0618;NETSDK1138</NoWarn>
+        <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
         <NoWarn>$(NoWarn);CS1591;CS0618;NETSDK1138</NoWarn>

--- a/Samples/SvgRuntimeUpdates/SvgRuntimeUpdates.csproj
+++ b/Samples/SvgRuntimeUpdates/SvgRuntimeUpdates.csproj
@@ -3,10 +3,11 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
+        <Configurations>Debug;Release</Configurations>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <NoWarn>$(NoWarn);CS0618;NETSDK1138</NoWarn>
+        <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
         <NoWarn>$(NoWarn);CS1591;CS0618;NETSDK1138</NoWarn>

--- a/Source/DataTypes/SvgNumberCollection.cs
+++ b/Source/DataTypes/SvgNumberCollection.cs
@@ -64,7 +64,7 @@ namespace Svg
             foreach (var part in parts)
             {
                 var partValue = part.Value;
-                var result = StringParser.ToFloatAny(ref partValue);
+                var result = StringParser.ToFloatAny(partValue);
                 collection.Add(result);
             }
 

--- a/Source/DataTypes/SvgPointCollection.cs
+++ b/Source/DataTypes/SvgPointCollection.cs
@@ -63,7 +63,7 @@ namespace Svg
                 var coords = s.AsSpan().Trim();
                 var state = new CoordinateParserState(ref coords);
                 var result = new SvgPointCollection();
-                while (CoordinateParser.TryGetFloat(out var pointValue, ref coords, ref state))
+                while (CoordinateParser.TryGetFloat(out var pointValue, coords, ref state))
                 {
                     result.Add(new SvgUnit(SvgUnitType.User, pointValue));
                 }

--- a/Source/DataTypes/SvgUnitConverter.cs
+++ b/Source/DataTypes/SvgUnitConverter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Globalization;
 using Svg.Helpers;
@@ -81,7 +81,7 @@ namespace Svg
             }
 
             var valSpan = identifierIndex > -1 ? unit.Slice(0, identifierIndex) : unit;
-            var val = StringParser.ToFloat(ref valSpan);
+            var val = StringParser.ToFloat(valSpan);
             if (identifierIndex == -1)
             {
                 return new SvgUnit(val);

--- a/Source/Exceptions/SvgException.cs
+++ b/Source/Exceptions/SvgException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+#if !NET8_0_OR_GREATER
 using System.Runtime.Serialization;
+#endif
 
 namespace Svg
 {
@@ -10,8 +12,10 @@ namespace Svg
         public SvgException(string message) : base(message) { }
         public SvgException(string message, Exception inner) : base(message, inner) { }
 
+#if !NET8_0_OR_GREATER
         protected SvgException(SerializationInfo info, StreamingContext context)
             : base (info, context) { }
+#endif
     }
 
     [Serializable]
@@ -21,8 +25,10 @@ namespace Svg
         public SvgIDException(string message) : base(message) { }
         public SvgIDException(string message, Exception inner) : base(message, inner) { }
 
+#if !NET8_0_OR_GREATER
         protected SvgIDException(SerializationInfo info, StreamingContext context)
             : base(info, context) { }
+#endif
     }
 
     [Serializable]
@@ -32,8 +38,10 @@ namespace Svg
         public SvgIDExistsException(string message) : base(message) { }
         public SvgIDExistsException(string message, Exception inner) : base(message, inner) { }
 
+#if !NET8_0_OR_GREATER
         protected SvgIDExistsException(SerializationInfo info, StreamingContext context)
             : base(info, context) { }
+#endif
     }
 
     [Serializable]
@@ -43,7 +51,9 @@ namespace Svg
         public SvgIDWrongFormatException(string message) : base(message) { }
         public SvgIDWrongFormatException(string message, Exception inner) : base(message, inner) { }
 
+#if !NET8_0_OR_GREATER
         protected SvgIDWrongFormatException(SerializationInfo info, StreamingContext context)
             : base(info, context) { }
+#endif
     }
 }

--- a/Source/Exceptions/SvgGdiPlusCannotBeLoadedException.cs
+++ b/Source/Exceptions/SvgGdiPlusCannotBeLoadedException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+#if !NET8_0_OR_GREATER
 using System.Runtime.Serialization;
+#endif
 
 namespace Svg
 {
@@ -13,7 +15,9 @@ namespace Svg
         public SvgGdiPlusCannotBeLoadedException(Exception inner) : base(gdiErrorMsg, inner) {}
         public SvgGdiPlusCannotBeLoadedException(string message, Exception inner) : base(message, inner) { }
 
+#if !NET8_0_OR_GREATER
         protected SvgGdiPlusCannotBeLoadedException(SerializationInfo info, StreamingContext context)
             : base(info, context) { }
+#endif
     }
 }

--- a/Source/Exceptions/SvgMemoryException.cs
+++ b/Source/Exceptions/SvgMemoryException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+#if !NET8_0_OR_GREATER
 using System.Runtime.Serialization;
+#endif
 
 namespace Svg.Exceptions
 {
@@ -10,7 +12,9 @@ namespace Svg.Exceptions
         public SvgMemoryException(string message) : base(message) { }
         public SvgMemoryException(string message, Exception inner) : base(message, inner) { }
 
+#if !NET8_0_OR_GREATER
         protected SvgMemoryException(SerializationInfo info, StreamingContext context)
             : base(info, context) { }
+#endif
     }
 }

--- a/Source/Helpers/StringParser.cs
+++ b/Source/Helpers/StringParser.cs
@@ -7,7 +7,7 @@ namespace Svg.Helpers
     {
         private static readonly CultureInfo Format = CultureInfo.InvariantCulture;
 
-        public static float ToFloat(ref ReadOnlySpan<char> value)
+        public static float ToFloat(ReadOnlySpan<char> value)
         {
 #if NETSTANDARD2_1 || NETCOREAPP2_1_OR_GREATER
             return float.Parse(value, NumberStyles.Float, Format);
@@ -16,7 +16,7 @@ namespace Svg.Helpers
 #endif
         }
 
-        public static float ToFloatAny(ref ReadOnlySpan<char> value)
+        public static float ToFloatAny(ReadOnlySpan<char> value)
         {
 #if NETSTANDARD2_1 || NETCOREAPP2_1_OR_GREATER
             return float.Parse(value, NumberStyles.Any, Format);
@@ -25,7 +25,7 @@ namespace Svg.Helpers
 #endif
         }
 
-        public static double ToDouble(ref ReadOnlySpan<char> value)
+        public static double ToDouble(ReadOnlySpan<char> value)
         {
 #if NETSTANDARD2_1 || NETCOREAPP2_1_OR_GREATER
             return double.Parse(value, NumberStyles.Any, Format);
@@ -34,7 +34,7 @@ namespace Svg.Helpers
 #endif
         }
 
-        public static int ToInt(ref ReadOnlySpan<char> value)
+        public static int ToInt(ReadOnlySpan<char> value)
         {
 #if NETSTANDARD2_1 || NETCOREAPP2_1_OR_GREATER
             return int.Parse(value, NumberStyles.Integer, Format);

--- a/Source/Paths/CoordinateParser.cs
+++ b/Source/Paths/CoordinateParser.cs
@@ -44,7 +44,7 @@ namespace Svg
             return hasMode;
         }
 
-        public static bool TryGetBool(out bool result, ref ReadOnlySpan<char> chars, ref CoordinateParserState state)
+        public static bool TryGetBool(out bool result, ReadOnlySpan<char> chars, ref CoordinateParserState state)
         {
             var charsLength = chars.Length;
 
@@ -88,7 +88,7 @@ namespace Svg
             return MarkState(false, ref state);
         }
 
-        public static bool TryGetFloat(out float result, ref ReadOnlySpan<char> chars, ref CoordinateParserState state)
+        public static bool TryGetFloat(out float result, ReadOnlySpan<char> chars, ref CoordinateParserState state)
         {
             var charsLength = chars.Length;
 
@@ -289,7 +289,7 @@ namespace Svg
                 if (state.CurrNumState != NumState.Separator && state.NewNumState < state.CurrNumState)
                 {
                     var value = chars.Slice(state.Position, state.CharsPosition - state.Position);
-                    result = StringParser.ToFloat(ref value);
+                    result = StringParser.ToFloat(value);
                     state.Position = state.CharsPosition;
                     state.CurrNumState = state.NewNumState;
                     return MarkState(true, ref state);
@@ -316,7 +316,7 @@ namespace Svg
             else
             {
                 var value = chars.Slice(state.Position, charsLength - state.Position);
-                result = StringParser.ToFloat(ref value);
+                result = StringParser.ToFloat(value);
                 state.Position = charsLength;
                 return MarkState(true, ref state);
             }

--- a/Source/Paths/SvgPathBuilder.cs
+++ b/Source/Paths/SvgPathBuilder.cs
@@ -51,14 +51,14 @@ namespace Svg
                         {
                             var commandSetTrimmed = pathTrimmed.Slice(start, length).Trim();
                             var state = new CoordinateParserState(ref commandSetTrimmed);
-                            CreatePathSegment(commandSetTrimmed[0], segments, ref state, ref commandSetTrimmed);
+                            CreatePathSegment(commandSetTrimmed[0], segments, ref state, commandSetTrimmed);
                         }
 
                         if (pathLength == i + 1)
                         {
                             var commandSetTrimmed = pathTrimmed.Slice(i, 1).Trim();
                             var state = new CoordinateParserState(ref commandSetTrimmed);
-                            CreatePathSegment(commandSetTrimmed[0], segments, ref state, ref commandSetTrimmed);
+                            CreatePathSegment(commandSetTrimmed[0], segments, ref state, commandSetTrimmed);
                         }
                     }
                     else if (pathLength == i + 1)
@@ -71,7 +71,7 @@ namespace Svg
                         {
                             var commandSetTrimmed = pathTrimmed.Slice(start, length).Trim();
                             var state = new CoordinateParserState(ref commandSetTrimmed);
-                            CreatePathSegment(commandSetTrimmed[0], segments, ref state, ref commandSetTrimmed);
+                            CreatePathSegment(commandSetTrimmed[0], segments, ref state, commandSetTrimmed);
                         }
                     }
                 }
@@ -84,7 +84,7 @@ namespace Svg
             return segments;
         }
 
-        private static void CreatePathSegment(char command, SvgPathSegmentList segments, ref CoordinateParserState state, ref ReadOnlySpan<char> chars)
+        private static void CreatePathSegment(char command, SvgPathSegmentList segments, ref CoordinateParserState state, ReadOnlySpan<char> chars)
         {
             var isRelative = char.IsLower(command);
             // http://www.w3.org/TR/SVG11/paths.html#PathDataGeneralInformation
@@ -94,15 +94,15 @@ namespace Svg
                 case 'M': // moveto
                 case 'm': // relative moveto
                     {
-                        if (CoordinateParser.TryGetFloat(out var coords0, ref chars, ref state)
-                         && CoordinateParser.TryGetFloat(out var coords1, ref chars, ref state))
+                        if (CoordinateParser.TryGetFloat(out var coords0, chars, ref state)
+                         && CoordinateParser.TryGetFloat(out var coords1, chars, ref state))
                         {
                             segments.Add(
                                 new SvgMoveToSegment(
                                     isRelative, new PointF(coords0, coords1)));
                         }
-                        while (CoordinateParser.TryGetFloat(out coords0, ref chars, ref state)
-                            && CoordinateParser.TryGetFloat(out coords1, ref chars, ref state))
+                        while (CoordinateParser.TryGetFloat(out coords0, chars, ref state)
+                            && CoordinateParser.TryGetFloat(out coords1, chars, ref state))
                         {
                             segments.Add(
                                 new SvgLineSegment(
@@ -113,13 +113,13 @@ namespace Svg
                 case 'A': // elliptical arc
                 case 'a': // relative elliptical arc
                     {
-                        while (CoordinateParser.TryGetFloat(out var coords0, ref chars, ref state)
-                            && CoordinateParser.TryGetFloat(out var coords1, ref chars, ref state)
-                            && CoordinateParser.TryGetFloat(out var coords2, ref chars, ref state)
-                            && CoordinateParser.TryGetBool(out var size, ref chars, ref state)
-                            && CoordinateParser.TryGetBool(out var sweep, ref chars, ref state)
-                            && CoordinateParser.TryGetFloat(out var coords3, ref chars, ref state)
-                            && CoordinateParser.TryGetFloat(out var coords4, ref chars, ref state))
+                        while (CoordinateParser.TryGetFloat(out var coords0, chars, ref state)
+                            && CoordinateParser.TryGetFloat(out var coords1, chars, ref state)
+                            && CoordinateParser.TryGetFloat(out var coords2, chars, ref state)
+                            && CoordinateParser.TryGetBool(out var size, chars, ref state)
+                            && CoordinateParser.TryGetBool(out var sweep, chars, ref state)
+                            && CoordinateParser.TryGetFloat(out var coords3, chars, ref state)
+                            && CoordinateParser.TryGetFloat(out var coords4, chars, ref state))
                         {
                             // A|a rx ry x-axis-rotation large-arc-flag sweep-flag x y
                             segments.Add(
@@ -136,8 +136,8 @@ namespace Svg
                 case 'L': // lineto
                 case 'l': // relative lineto
                     {
-                        while (CoordinateParser.TryGetFloat(out var coords0, ref chars, ref state)
-                            && CoordinateParser.TryGetFloat(out var coords1, ref chars, ref state))
+                        while (CoordinateParser.TryGetFloat(out var coords0, chars, ref state)
+                            && CoordinateParser.TryGetFloat(out var coords1, chars, ref state))
                         {
                             segments.Add(
                                 new SvgLineSegment(
@@ -148,7 +148,7 @@ namespace Svg
                 case 'H': // horizontal lineto
                 case 'h': // relative horizontal lineto
                     {
-                        while (CoordinateParser.TryGetFloat(out var coords0, ref chars, ref state))
+                        while (CoordinateParser.TryGetFloat(out var coords0, chars, ref state))
                         {
                             segments.Add(
                                 new SvgLineSegment(
@@ -159,7 +159,7 @@ namespace Svg
                 case 'V': // vertical lineto
                 case 'v': // relative vertical lineto
                     {
-                        while (CoordinateParser.TryGetFloat(out var coords0, ref chars, ref state))
+                        while (CoordinateParser.TryGetFloat(out var coords0, chars, ref state))
                         {
                             segments.Add(
                                 new SvgLineSegment(
@@ -170,10 +170,10 @@ namespace Svg
                 case 'Q': // quadratic bézier curveto
                 case 'q': // relative quadratic bézier curveto
                     {
-                        while (CoordinateParser.TryGetFloat(out var coords0, ref chars, ref state)
-                            && CoordinateParser.TryGetFloat(out var coords1, ref chars, ref state)
-                            && CoordinateParser.TryGetFloat(out var coords2, ref chars, ref state)
-                            && CoordinateParser.TryGetFloat(out var coords3, ref chars, ref state))
+                        while (CoordinateParser.TryGetFloat(out var coords0, chars, ref state)
+                            && CoordinateParser.TryGetFloat(out var coords1, chars, ref state)
+                            && CoordinateParser.TryGetFloat(out var coords2, chars, ref state)
+                            && CoordinateParser.TryGetFloat(out var coords3, chars, ref state))
                         {
                             segments.Add(
                                 new SvgQuadraticCurveSegment(
@@ -186,8 +186,8 @@ namespace Svg
                 case 'T': // shorthand/smooth quadratic bézier curveto
                 case 't': // relative shorthand/smooth quadratic bézier curveto
                     {
-                        while (CoordinateParser.TryGetFloat(out var coords0, ref chars, ref state)
-                            && CoordinateParser.TryGetFloat(out var coords1, ref chars, ref state))
+                        while (CoordinateParser.TryGetFloat(out var coords0, chars, ref state)
+                            && CoordinateParser.TryGetFloat(out var coords1, chars, ref state))
                         {
                             segments.Add(
                                 new SvgQuadraticCurveSegment(
@@ -198,12 +198,12 @@ namespace Svg
                 case 'C': // curveto
                 case 'c': // relative curveto
                     {
-                    while (CoordinateParser.TryGetFloat(out var coords0, ref chars, ref state)
-                        && CoordinateParser.TryGetFloat(out var coords1, ref chars, ref state)
-                        && CoordinateParser.TryGetFloat(out var coords2, ref chars, ref state)
-                        && CoordinateParser.TryGetFloat(out var coords3, ref chars, ref state)
-                        && CoordinateParser.TryGetFloat(out var coords4, ref chars, ref state)
-                        && CoordinateParser.TryGetFloat(out var coords5, ref chars, ref state))
+                    while (CoordinateParser.TryGetFloat(out var coords0, chars, ref state)
+                        && CoordinateParser.TryGetFloat(out var coords1, chars, ref state)
+                        && CoordinateParser.TryGetFloat(out var coords2, chars, ref state)
+                        && CoordinateParser.TryGetFloat(out var coords3, chars, ref state)
+                        && CoordinateParser.TryGetFloat(out var coords4, chars, ref state)
+                        && CoordinateParser.TryGetFloat(out var coords5, chars, ref state))
                     {
                         segments.Add(
                             new SvgCubicCurveSegment(
@@ -217,10 +217,10 @@ namespace Svg
                 case 'S': // shorthand/smooth curveto
                 case 's': // relative shorthand/smooth curveto
                     {
-                        while (CoordinateParser.TryGetFloat(out var coords0, ref chars, ref state)
-                            && CoordinateParser.TryGetFloat(out var coords1, ref chars, ref state)
-                            && CoordinateParser.TryGetFloat(out var coords2, ref chars, ref state)
-                            && CoordinateParser.TryGetFloat(out var coords3, ref chars, ref state))
+                        while (CoordinateParser.TryGetFloat(out var coords0, chars, ref state)
+                            && CoordinateParser.TryGetFloat(out var coords1, chars, ref state)
+                            && CoordinateParser.TryGetFloat(out var coords2, chars, ref state)
+                            && CoordinateParser.TryGetFloat(out var coords3, chars, ref state))
                         {
                             segments.Add(
                                 new SvgCubicCurveSegment(

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.1;netstandard2.0;net462;net472;net481</TargetFrameworks>
+        <TargetFrameworks>net8.0;net6.0;netcoreapp3.1;netstandard2.1;netstandard2.0;net462;net472;net481</TargetFrameworks>
         <PackageLicenseExpression>MS-PL</PackageLicenseExpression>
         <RootNamespace>Svg</RootNamespace>
         <AssemblyName>Svg</AssemblyName>
@@ -141,6 +141,10 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Compile Remove="$(CompilerGeneratedFilesOutputPath)/**/*.cs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -44,7 +44,7 @@
         <DebugType>full</DebugType>
         <DebugSymbols>true</DebugSymbols>
         <DefineConstants>DEBUG;TRACE</DefineConstants>
-        <NoWarn>$(NoWarn);CS0618;NETSDK1138</NoWarn>
+        <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/Source/Svg.sln
+++ b/Source/Svg.sln
@@ -10,9 +10,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A417AF1E-BEDB-4715-B4FD-D795579217F9}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
-		Local.testsettings = Local.testsettings
-		Svg.vsmdi = Svg.vsmdi
-		TraceAndTestImpact.testsettings = TraceAndTestImpact.testsettings
 		version.json = version.json
 	EndProjectSection
 EndProject
@@ -40,7 +37,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Generators", "Generators", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Svg.Custom", "..\Svg.Custom\Svg.Custom.csproj", "{6FAA2B79-FE5C-456B-A743-E9290665B223}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Svg.Tests.Common", "..\Tests\Svg.Tests.Common\Svg.Tests.Common.csproj", "{D7C625E8-79EA-4859-A457-2C4A90786790}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Svg.Tests.Common", "..\Tests\Svg.Tests.Common\Svg.Tests.Common.csproj", "{D7C625E8-79EA-4859-A457-2C4A90786790}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Source/Transforms/SvgTransformConverter.cs
+++ b/Source/Transforms/SvgTransformConverter.cs
@@ -99,11 +99,11 @@ namespace Svg.Transforms
                             var partValue = part.Value;
                             if (count == 0)
                             {
-                                x = StringParser.ToFloat(ref partValue);
+                                x = StringParser.ToFloat(partValue);
                             }
                             else if (count == 1)
                             {
-                                y = StringParser.ToFloat(ref partValue);
+                                y = StringParser.ToFloat(partValue);
                             }
 
                             count++;
@@ -129,15 +129,15 @@ namespace Svg.Transforms
                             var partValue = part.Value;
                             if (count == 0)
                             {
-                                angle = StringParser.ToFloat(ref partValue);
+                                angle = StringParser.ToFloat(partValue);
                             }
                             else if (count == 1)
                             {
-                                cx = StringParser.ToFloat(ref partValue);
+                                cx = StringParser.ToFloat(partValue);
                             }
                             else if (count == 2)
                             {
-                                cy = StringParser.ToFloat(ref partValue);
+                                cy = StringParser.ToFloat(partValue);
                             }
 
                             count++;
@@ -162,11 +162,11 @@ namespace Svg.Transforms
                             var partValue = part.Value;
                             if (count == 0)
                             {
-                                sx = StringParser.ToFloat(ref partValue);
+                                sx = StringParser.ToFloat(partValue);
                             }
                             else if (count == 1)
                             {
-                                sy = StringParser.ToFloat(ref partValue);
+                                sy = StringParser.ToFloat(partValue);
                             }
 
                             count++;
@@ -195,27 +195,27 @@ namespace Svg.Transforms
                             var partValue = part.Value;
                             if (count == 0)
                             {
-                                m11 = StringParser.ToFloat(ref partValue);
+                                m11 = StringParser.ToFloat(partValue);
                             }
                             else if (count == 1)
                             {
-                                m12 = StringParser.ToFloat(ref partValue);
+                                m12 = StringParser.ToFloat(partValue);
                             }
                             else if (count == 2)
                             {
-                                m21 = StringParser.ToFloat(ref partValue);
+                                m21 = StringParser.ToFloat(partValue);
                             }
                             else if (count == 3)
                             {
-                                m22 = StringParser.ToFloat(ref partValue);
+                                m22 = StringParser.ToFloat(partValue);
                             }
                             else if (count == 4)
                             {
-                                dx = StringParser.ToFloat(ref partValue);
+                                dx = StringParser.ToFloat(partValue);
                             }
                             else if (count == 5)
                             {
-                                dy = StringParser.ToFloat(ref partValue);
+                                dy = StringParser.ToFloat(partValue);
                             }
 
                             count++;
@@ -241,11 +241,11 @@ namespace Svg.Transforms
                             var partValue = part.Value;
                             if (count == 0)
                             {
-                                hx = StringParser.ToFloat(ref partValue);
+                                hx = StringParser.ToFloat(partValue);
                             }
                             else if (count == 1)
                             {
-                                hy = StringParser.ToFloat(ref partValue);
+                                hy = StringParser.ToFloat(partValue);
                             }
 
                             count++;
@@ -269,7 +269,7 @@ namespace Svg.Transforms
                             var partValue = part.Value;
                             if (count == 0)
                             {
-                                ax = StringParser.ToFloat(ref partValue);
+                                ax = StringParser.ToFloat(partValue);
                             }
 
                             count++;
@@ -293,7 +293,7 @@ namespace Svg.Transforms
                             var partValue = part.Value;
                             if (count == 0)
                             {
-                                ay = StringParser.ToFloat(ref partValue);
+                                ay = StringParser.ToFloat(partValue);
                             }
 
                             count++;

--- a/Svg.Custom/Svg.Custom.csproj
+++ b/Svg.Custom/Svg.Custom.csproj
@@ -3,7 +3,7 @@
     <!-- https://github.com/wieslawsoltes/Svg.Skia/blob/master/src/Svg.Custom/Svg.Custom.csproj -->
     <PropertyGroup>
         <OutputType>Library</OutputType>
-        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
         <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
         <EnableDefaultItems>False</EnableDefaultItems>
         <GenerateAssemblyInfo>True</GenerateAssemblyInfo>

--- a/Tests/Svg.Benchmark.sln
+++ b/Tests/Svg.Benchmark.sln
@@ -1,0 +1,61 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34408.163
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Svg", "..\Source\Svg.csproj", "{886A98C5-37C0-4E8B-885E-30C1D2F98B47}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A417AF1E-BEDB-4715-B4FD-D795579217F9}"
+	ProjectSection(SolutionItems) = preProject
+		..\Source\.editorconfig = ..\Source\.editorconfig
+		..\Source\version.json = ..\Source\version.json
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{2EC3F3A0-F097-43EF-A603-9B82E3061469}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Svg.Generators", "..\Generators\Svg.Generators.csproj", "{BACDD1F4-B97D-4E27-BD09-6957633FF484}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Svg.Benchmark", "Svg.Benchmark\Svg.Benchmark.csproj", "{8DEB3EA7-5915-4EB9-8052-85A7AC4379EC}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Generators", "Generators", "{FAFD6DC7-5203-4CED-A151-66379DD43695}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Svg.Tests.Common", "Svg.Tests.Common\Svg.Tests.Common.csproj", "{D7C625E8-79EA-4859-A457-2C4A90786790}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{886A98C5-37C0-4E8B-885E-30C1D2F98B47}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{886A98C5-37C0-4E8B-885E-30C1D2F98B47}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{886A98C5-37C0-4E8B-885E-30C1D2F98B47}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{886A98C5-37C0-4E8B-885E-30C1D2F98B47}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BACDD1F4-B97D-4E27-BD09-6957633FF484}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BACDD1F4-B97D-4E27-BD09-6957633FF484}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BACDD1F4-B97D-4E27-BD09-6957633FF484}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BACDD1F4-B97D-4E27-BD09-6957633FF484}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8DEB3EA7-5915-4EB9-8052-85A7AC4379EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8DEB3EA7-5915-4EB9-8052-85A7AC4379EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8DEB3EA7-5915-4EB9-8052-85A7AC4379EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8DEB3EA7-5915-4EB9-8052-85A7AC4379EC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D7C625E8-79EA-4859-A457-2C4A90786790}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D7C625E8-79EA-4859-A457-2C4A90786790}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D7C625E8-79EA-4859-A457-2C4A90786790}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D7C625E8-79EA-4859-A457-2C4A90786790}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{BACDD1F4-B97D-4E27-BD09-6957633FF484} = {FAFD6DC7-5203-4CED-A151-66379DD43695}
+		{8DEB3EA7-5915-4EB9-8052-85A7AC4379EC} = {2EC3F3A0-F097-43EF-A603-9B82E3061469}
+		{D7C625E8-79EA-4859-A457-2C4A90786790} = {2EC3F3A0-F097-43EF-A603-9B82E3061469}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5096EEB3-8F41-44B5-BCF9-58743A59AB21}
+	EndGlobalSection
+	GlobalSection(TestCaseManagementSettings) = postSolution
+		CategoryFile = Svg.vsmdi
+	EndGlobalSection
+EndGlobal

--- a/Tests/Svg.Benchmark/CoordinateParserBenchmarks.cs
+++ b/Tests/Svg.Benchmark/CoordinateParserBenchmarks.cs
@@ -12,7 +12,7 @@ namespace Svg.Benchmark
         {
             var chars = "false".AsSpan().Trim();
             var state = new CoordinateParserState(ref chars);
-            CoordinateParser.TryGetBool(out var result, ref chars, ref state);
+            CoordinateParser.TryGetBool(out var result, chars, ref state);
         }
 
         [Benchmark]
@@ -20,7 +20,7 @@ namespace Svg.Benchmark
         {
             var chars = "1.6,3.2 1.2,5".AsSpan().Trim();
             var state = new CoordinateParserState(ref chars);
-            while (CoordinateParser.TryGetFloat(out var result, ref chars, ref state))
+            while (CoordinateParser.TryGetFloat(out var result, chars, ref state))
             {
             }
         }

--- a/Tests/Svg.Benchmark/Svg.Benchmark.csproj
+++ b/Tests/Svg.Benchmark/Svg.Benchmark.csproj
@@ -6,10 +6,11 @@
         <LangVersion>10.0</LangVersion>
         <SignAssembly>True</SignAssembly>
         <AssemblyOriginatorKeyFile>..\Svg.UnitTests\svgkey.snk</AssemblyOriginatorKeyFile>
+        <Configurations>Debug;Release</Configurations>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <NoWarn>$(NoWarn);CS0618;NETSDK1138</NoWarn>
+        <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
         <NoWarn>$(NoWarn);CS1591;CS0618;NETSDK1138</NoWarn>

--- a/Tests/Svg.Benchmark/Svg.Benchmark.csproj
+++ b/Tests/Svg.Benchmark/Svg.Benchmark.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
+        <TargetFrameworks>net8.0;net6.0;netcoreapp3.1;net462</TargetFrameworks>
         <IsPackable>false</IsPackable>
-        <LangVersion>8.0</LangVersion>
+        <LangVersion>10.0</LangVersion>
         <SignAssembly>True</SignAssembly>
         <AssemblyOriginatorKeyFile>..\Svg.UnitTests\svgkey.snk</AssemblyOriginatorKeyFile>
     </PropertyGroup>

--- a/Tests/Svg.Tests.Common/Svg.Tests.Common.csproj
+++ b/Tests/Svg.Tests.Common/Svg.Tests.Common.csproj
@@ -8,6 +8,7 @@
         <SignAssembly>True</SignAssembly>
         <AssemblyOriginatorKeyFile>svgkey.snk</AssemblyOriginatorKeyFile>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+        <Configurations>Debug;Release</Configurations>
     </PropertyGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net462'">

--- a/Tests/Svg.Tests.Common/Svg.Tests.Common.csproj
+++ b/Tests/Svg.Tests.Common/Svg.Tests.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
+        <TargetFrameworks>net8.0;net6.0;netcoreapp3.1;net462</TargetFrameworks>
         <SignAssembly>False</SignAssembly>
         <DelaySign>False</DelaySign>
         <IsPackable>False</IsPackable>

--- a/Tests/Svg.UnitTests.sln
+++ b/Tests/Svg.UnitTests.sln
@@ -1,0 +1,61 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34408.163
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Svg", "..\Source\Svg.csproj", "{886A98C5-37C0-4E8B-885E-30C1D2F98B47}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Svg.UnitTests", "Svg.UnitTests\Svg.UnitTests.csproj", "{E702EB7D-D01D-438A-BADD-E72D4E49109F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A417AF1E-BEDB-4715-B4FD-D795579217F9}"
+	ProjectSection(SolutionItems) = preProject
+		..\Source\.editorconfig = ..\Source\.editorconfig
+		..\Source\version.json = ..\Source\version.json
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{2EC3F3A0-F097-43EF-A603-9B82E3061469}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Svg.Generators", "..\Generators\Svg.Generators.csproj", "{BACDD1F4-B97D-4E27-BD09-6957633FF484}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Generators", "Generators", "{FAFD6DC7-5203-4CED-A151-66379DD43695}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Svg.Tests.Common", "Svg.Tests.Common\Svg.Tests.Common.csproj", "{D7C625E8-79EA-4859-A457-2C4A90786790}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{886A98C5-37C0-4E8B-885E-30C1D2F98B47}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{886A98C5-37C0-4E8B-885E-30C1D2F98B47}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{886A98C5-37C0-4E8B-885E-30C1D2F98B47}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{886A98C5-37C0-4E8B-885E-30C1D2F98B47}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E702EB7D-D01D-438A-BADD-E72D4E49109F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E702EB7D-D01D-438A-BADD-E72D4E49109F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E702EB7D-D01D-438A-BADD-E72D4E49109F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E702EB7D-D01D-438A-BADD-E72D4E49109F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BACDD1F4-B97D-4E27-BD09-6957633FF484}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BACDD1F4-B97D-4E27-BD09-6957633FF484}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BACDD1F4-B97D-4E27-BD09-6957633FF484}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BACDD1F4-B97D-4E27-BD09-6957633FF484}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D7C625E8-79EA-4859-A457-2C4A90786790}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D7C625E8-79EA-4859-A457-2C4A90786790}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D7C625E8-79EA-4859-A457-2C4A90786790}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D7C625E8-79EA-4859-A457-2C4A90786790}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{E702EB7D-D01D-438A-BADD-E72D4E49109F} = {2EC3F3A0-F097-43EF-A603-9B82E3061469}
+		{BACDD1F4-B97D-4E27-BD09-6957633FF484} = {FAFD6DC7-5203-4CED-A151-66379DD43695}
+		{D7C625E8-79EA-4859-A457-2C4A90786790} = {2EC3F3A0-F097-43EF-A603-9B82E3061469}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5096EEB3-8F41-44B5-BCF9-58743A59AB21}
+	EndGlobalSection
+	GlobalSection(TestCaseManagementSettings) = postSolution
+		CategoryFile = Svg.vsmdi
+	EndGlobalSection
+EndGlobal

--- a/Tests/Svg.UnitTests/Svg.UnitTests.csproj
+++ b/Tests/Svg.UnitTests/Svg.UnitTests.csproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <IsTestProject>true</IsTestProject>
-        <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
+        <TargetFrameworks>net8.0;net6.0;netcoreapp3.1;net462</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>svgkey.snk</AssemblyOriginatorKeyFile>
         <DelaySign>false</DelaySign>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <Configurations>Debug;Release</Configurations>
-        <NoWarn>1591</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Tests/Svg.UnitTests/Svg.UnitTests.csproj
+++ b/Tests/Svg.UnitTests/Svg.UnitTests.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <NoWarn>$(NoWarn);CS0618;NETSDK1138</NoWarn>
+        <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
         <NoWarn>$(NoWarn);CS1591;CS0618;NETSDK1138</NoWarn>

--- a/Tests/SvgW3CTestRunner/Properties/AssemblyInfo.cs
+++ b/Tests/SvgW3CTestRunner/Properties/AssemblyInfo.cs
@@ -33,3 +33,6 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+#if NET5_0_OR_GREATER
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("windows7.0")]
+#endif

--- a/Tests/SvgW3CTestRunner/SvgW3CTestRunner.csproj
+++ b/Tests/SvgW3CTestRunner/SvgW3CTestRunner.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFrameworks>net6.0-windows;netcoreapp3.1;net462</TargetFrameworks>
+        <TargetFrameworks>net8.0-windows;net6.0-windows;netcoreapp3.1;net462</TargetFrameworks>
         <UseWindowsForms>true</UseWindowsForms>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/Tests/SvgW3CTestRunner/SvgW3CTestRunner.csproj
+++ b/Tests/SvgW3CTestRunner/SvgW3CTestRunner.csproj
@@ -7,10 +7,11 @@
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
         <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+        <Configurations>Debug;Release</Configurations>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <NoWarn>$(NoWarn);CS0618;NETSDK1138</NoWarn>
+        <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
         <NoWarn>$(NoWarn);CS1591;CS0618;NETSDK1138</NoWarn>

--- a/doc/ReleaseNotes.md
+++ b/doc/ReleaseNotes.md
@@ -4,9 +4,15 @@ The release versions are NuGet releases.
 ## Unreleased
 
 ### Changes
-* added SvgOptions with css parameter to Open so that this can be used for transforming the svgdocument.
+* Added: A class, `SvgOptions`, with external css parameters for styling or transforming the `SvgDocument`.
 * Split tests SVG/PNG files into Issues and W3C Test Suite. W3C Test Suite files are not automatically downloaded.
 * Repository clean-up, reducing the download zip size from 22MB to 4.5MB.
+* Added: Support for .NET 4.7.2, .NET 4.8.1 and .NET 8.0.
+* Added: A new project, `Tests/Svg.Tests.Common` for sharing codes between test applications.
+* [Breaking change] The support for .NET 8 resulted in a breaking change to the signature of methods in `CoordinateParser`.
+  * The changes are needed to fix a compiler error `CS8352`.
+  * The use of read-only arguments as referenced variable is not necessary.
+  * The use of `ref` in the function arguements resulting in `CS8352` error are all removed.
 
 ### Enhancements
 * made exceptions serializable to be able to cross AppDomain boundaries (see [#826](https://github.com/svg-net/SVG/pull/826))


### PR DESCRIPTION
### Description
- Updated test and sample projects to support .NET 8
- Fixed compile warnings and errors including CS8352, CA1416
- Initial update to the tests workflow (`runtests.yml`)
- Removed previously deleted items from the solution file.

### Type of change
- [x] Fixing the `CS8352` compiler error requires breaking changes to `CoordinateParser` (`StringParser` is internal)
- [x] This change does require a documentation update
- [x] Updates to `runtest.yml`, includes
  - Dotnet runtime upgrade to .NET 8 for benchmark.
  - For the unit-tests, .NetCore 3.1 runtime is maintained in addition to .NET 8 
  - `actions/checkout` version v2 to v4
  - `actions/cache` version v1 to v4
  - `actions/setup-dotnet` versions v3 to v4
  - `NUnit.ConsoleRunner` version 3.10.0 to 3.17.0
- [x] The unit-tests now run in release configuration similar to the benchmark 
- [x] Update revision notes
- [x] Resolved review issues.

### How Has This Been Tested?
- [x] SvgW3CTestRunner is tested for each supported platform
- [x] Svg.UnitTests tested on command line for each supported platform
- [x] Svg.Benchmarks tested on command line for each supported platform, warnings are as before will be addressed later.