### PR TITLE
Fix <CompilerGeneratedFilesOutputPath> in Svg.Custom.

### DIFF
--- a/Docs/articles/ReleaseNotes.md
+++ b/Docs/articles/ReleaseNotes.md
@@ -1,6 +1,11 @@
 # SVG.NET Release Notes
 The release versions are NuGet releases.
 
+## Unreleased
+
+### Fixes
+* Fixed: `<CompilerGeneratedFilesOutputPath>` in `Svg.Custom` to generate `Generated` directory under project. (see [PR #1153](https://github.com/svg-net/SVG/pull/1153))
+
 ## [Version 3.4.7](https://www.nuget.org/packages/Svg/3.4.7)  (2024-02-22)
 
 ### Changes

--- a/Tests/Svg.Custom/Svg.Custom.csproj
+++ b/Tests/Svg.Custom/Svg.Custom.csproj
@@ -11,7 +11,8 @@
         <IsPackable>True</IsPackable>
         <Nullable>disable</Nullable>
         <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-        <CompilerGeneratedFilesOutputPath>$(SvgSourcesBasePath)\Generated</CompilerGeneratedFilesOutputPath>
+        <SvgRootPath>..\..</SvgRootPath>
+        <CompilerGeneratedFilesOutputPath>$(SvgRootPath)\Source\Generated</CompilerGeneratedFilesOutputPath>
         <DefineConstants>$(DefineConstants);NO_SDC</DefineConstants>
         <LangVersion>10.0</LangVersion>
     </PropertyGroup>
@@ -23,13 +24,9 @@
         <PackageTags>svg;vector graphics;rendering;2d;graphics;geometry;shapes</PackageTags>
     </PropertyGroup>
 
-    <PropertyGroup>
-        <SvgSourcesBasePath>..\..</SvgSourcesBasePath>
-    </PropertyGroup>
-
     <ItemGroup>
         <!-- https://github.com/vvvv/SVG/blob/master/Source/SvgDtdResolver.cs#L32 -->
-        <EmbeddedResource Include="$(SvgSourcesBasePath)\Source\Resources\svg11.dtd">
+        <EmbeddedResource Include="$(SvgRootPath)\Source\Resources\svg11.dtd">
             <Link>Resources\svg11.dtd</Link>
             <LogicalName>Svg.Resources.svg11.dtd</LogicalName>
         </EmbeddedResource>
@@ -37,14 +34,14 @@
 
     <ItemGroup>
         <Compile Include="**\*.cs" Exclude="bin\**;obj\**" />
-        <Compile Include="$(SvgSourcesBasePath)\Source\**\*.cs" Exclude="$(SvgSourcesBasePath)\Source\obj\**" />
-        <Compile Remove="$(SvgSourcesBasePath)\Source\Properties\AssemblyInfo.cs" />
-        <Compile Remove="$(SvgSourcesBasePath)\Source\Resources\svg11.dtd" />
+        <Compile Include="$(SvgRootPath)\Source\**\*.cs" Exclude="$(SvgRootPath)\Source\obj\**" />
+        <Compile Remove="$(SvgRootPath)\Source\Properties\AssemblyInfo.cs" />
+        <Compile Remove="$(SvgRootPath)\Source\Resources\svg11.dtd" />
     </ItemGroup>
 
     <ItemGroup>
         <Compile Remove="$(CompilerGeneratedFilesOutputPath)/**/*.cs" />
-        <Compile Remove="$(SvgSourcesBasePath)\Source\Generated\**\*.cs" />
+        <Compile Remove="$(SvgRootPath)\Source\Generated\**\*.cs" />
     </ItemGroup>
 
     <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
@@ -68,7 +65,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="$(SvgSourcesBasePath)\Generators\Svg.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <ProjectReference Include="$(SvgRootPath)\Generators\Svg.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/vvvv/SVG/blob/master/CONTRIBUTING.md#contributing-code
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Ref. #1141

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the changes, if not self-evident.
-->

Because value of `<CompilerGeneratedFilesOutputPath>` is invalid, `Generated` directory is generated at root of execution environment.(ex: `c:\Generated`)

This PR will generate `Generated` under this project.

#### Any other comments?
<!--
-->

<!--
Thanks for contributing!
-->
