### PR TITLE
Add IsTrimmanle/IsAotCompatible attributes

### DIFF
--- a/Docs/articles/ReleaseNotes.md
+++ b/Docs/articles/ReleaseNotes.md
@@ -5,6 +5,7 @@ The release versions are NuGet releases.
 
 ### Enhancements
 * Added support for `Switch` element with "systemLanguage" selector attribute (see [#1176](https://github.com/svg-net/SVG/issues/1176)).
+* Enabled `IsTrimmable` and `IsAotCompatible` attributes on the assembly (see [#1184](https://github.com/svg-net/SVG/pull/1184)).
 
 ### Fixes
 * Fixed: `<CompilerGeneratedFilesOutputPath>` in `Svg.Custom` to generate `Generated` directory under project. (see [PR #1153](https://github.com/svg-net/SVG/pull/1153))

--- a/Source/DataTypes/SvgAspectRatio.cs
+++ b/Source/DataTypes/SvgAspectRatio.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Svg.DataTypes;
 
 namespace Svg
@@ -54,6 +55,11 @@ namespace Svg
             return MemberwiseClone();
         }
 
+#if NET6_0_OR_GREATER
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(SvgPreserveAspectRatioConverter))]
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "DynamicDependency keeps converter safe")]
+        [UnconditionalSuppressMessage("AOT", "IL3050")]
+#endif
         public override string ToString()
         {
             return TypeDescriptor.GetConverter(typeof(SvgPreserveAspectRatio)).ConvertToString(this.Align) + (Slice ? " slice" : "");

--- a/Source/DataTypes/SvgPoint.cs
+++ b/Source/DataTypes/SvgPoint.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using Svg.DataTypes;
 
 namespace Svg
 {
@@ -39,12 +41,16 @@ namespace Svg
             return base.GetHashCode();
         }
 
+#if NET6_0_OR_GREATER
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(SvgUnitConverter))]
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "DynamicDependency keeps converter safe")]
+#endif
         public SvgPoint(string x, string y)
         {
             TypeConverter converter = TypeDescriptor.GetConverter(typeof(SvgUnit));
 
-            this.x = (SvgUnit)converter.ConvertFrom(x);
-            this.y = (SvgUnit)converter.ConvertFrom(y);
+            this.x = (SvgUnit)converter.ConvertFrom(x)!;
+            this.y = (SvgUnit)converter.ConvertFrom(y)!;
         }
 
         public SvgPoint(SvgUnit x, SvgUnit y)

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -54,7 +54,19 @@
         <NoWarn>$(NoWarn);CS1591;CS0618;NETSDK1138</NoWarn>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
-    
+
+    <!-- Trimming parameters -->
+    <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+        <IsTrimmable>true</IsTrimmable>
+        <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+        <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    </PropertyGroup>
+    <!-- AOT parameters -->
+    <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+        <IsAotCompatible>true</IsAotCompatible>
+        <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    </PropertyGroup>
+
     <PropertyGroup>
         <DefineConstants Condition="$(TargetFramework.StartsWith('net46'))">$(DefineConstants);DOTNET46;NETFULL</DefineConstants>
         <DefineConstants Condition="$(TargetFramework.StartsWith('net47'))">$(DefineConstants);DOTNET47;NETFULL</DefineConstants>

--- a/Source/Svg.csproj
+++ b/Source/Svg.csproj
@@ -64,7 +64,6 @@
     <!-- AOT parameters -->
     <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
         <IsAotCompatible>true</IsAotCompatible>
-        <EnableAotAnalyzer>true</EnableAotAnalyzer>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR fixes several warnigns/erros that are reproducible during PublishAOT build with this library referenced:
```
    /_/externals/SVG/Source/DataTypes/SvgAspectRatio.cs(59): Trim analysis error IL2026: Svg.SvgAspectRatio.ToString(): Using member 'System.ComponentModel.TypeDescriptor.GetConverter(Type)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. Generic TypeConverters may require the generic types to be annotated. For example, NullableConverter requires the underlying type to be DynamicallyAccessedMembers All.
    /_/externals/SVG/Source/DataTypes/SvgAspectRatio.cs(59): AOT analysis error IL3050: Svg.SvgAspectRatio.ToString(): Using member 'System.Enum.GetValues(Type)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. It might not be possible to create an array of the enum type at runtime. Use the GetValues<TEnum> overload or the GetValuesAsUnderlyingType method instead.
```

These special attributes fix the problem by ensuring attributes are statically linked, and not removed from the assembly. Without changing any logic.

#### Any other comments?

It would be possible to avoid DynamicDependency attributes, by refactoring code to not depend on TypeDescriptors, but that would be much more involving change, and in my opinion unnecessary.
